### PR TITLE
✨[Feat] 일반 회원가입/일반 로그인 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,9 @@ dependencies {
 	// spring security
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	testImplementation 'org.springframework.security:spring-security-test'
+
+	//email verification
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,10 @@ dependencies {
 	// Swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-api:2.7.0'
+
+	// spring security
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+	testImplementation 'org.springframework.security:spring-security-test'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,11 @@ dependencies {
 
 	//email verification
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
+
+	//JWT
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/onenth/OneNth/domain/member/controller/EmailVerificationRestController.java
+++ b/src/main/java/com/onenth/OneNth/domain/member/controller/EmailVerificationRestController.java
@@ -1,0 +1,30 @@
+package com.onenth.OneNth.domain.member.controller;
+
+import com.onenth.OneNth.domain.member.dto.MemberRequestDTO;
+import com.onenth.OneNth.domain.member.service.EmailVerificationService.EmailVerificationService;
+import com.onenth.OneNth.global.apiPayload.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/email-auth")
+public class EmailVerificationRestController {
+
+    private final EmailVerificationService emailVerificationService;
+
+    @PostMapping("/request-code")
+    public ApiResponse<String> requestCode(@RequestBody MemberRequestDTO.EmailCodeRequestDTO request) {
+        emailVerificationService.sendCode(request.getEmail());
+        return ApiResponse.onSuccess("이메일로 인증번호가 전송되었습니다.");
+    }
+
+    @PostMapping("/verify-code")
+    public ApiResponse<String> verifyCode(@RequestBody MemberRequestDTO.VerifyCodeRequestDTO request) {
+        emailVerificationService.verifyCode(request.getEmail(), request.getCode());
+        return ApiResponse.onSuccess("이메일 인증이 완료되었습니다.");
+    }
+}

--- a/src/main/java/com/onenth/OneNth/domain/member/controller/EmailVerificationRestController.java
+++ b/src/main/java/com/onenth/OneNth/domain/member/controller/EmailVerificationRestController.java
@@ -3,6 +3,10 @@ package com.onenth.OneNth.domain.member.controller;
 import com.onenth.OneNth.domain.member.dto.MemberRequestDTO;
 import com.onenth.OneNth.domain.member.service.EmailVerificationService.EmailVerificationService;
 import com.onenth.OneNth.global.apiPayload.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -16,12 +20,34 @@ public class EmailVerificationRestController {
 
     private final EmailVerificationService emailVerificationService;
 
+    /**
+     * 회원가입을 위해 이메일로 인증 코드 발송 API
+     */
+    @Operation(
+            summary = "회원가입을 위한 이메일 인증 코드 발송 API",
+            description = "이메일로 인증 코드를 발송합니다. 이메일 인증에 사용하세요."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "잘못된 요청입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+    })
     @PostMapping("/request-code")
     public ApiResponse<String> requestCode(@RequestBody MemberRequestDTO.EmailCodeRequestDTO request) {
         emailVerificationService.sendCode(request.getEmail());
         return ApiResponse.onSuccess("이메일로 인증번호가 전송되었습니다.");
     }
 
+    /**
+     * 인증코드를 입력후 유효성 검증 API
+     */
+    @Operation(
+            summary = "회원가입을 위한 인증코드 검증 API",
+            description = "이메일로 발송된 인증코드를 검증합니다. 올바른 코드인지 확인하세요."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "잘못된 요청입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+    })
     @PostMapping("/verify-code")
     public ApiResponse<String> verifyCode(@RequestBody MemberRequestDTO.VerifyCodeRequestDTO request) {
         emailVerificationService.verifyCode(request.getEmail(), request.getCode());

--- a/src/main/java/com/onenth/OneNth/domain/member/controller/MemberRestController.java
+++ b/src/main/java/com/onenth/OneNth/domain/member/controller/MemberRestController.java
@@ -4,16 +4,15 @@ import com.onenth.OneNth.domain.member.dto.MemberRequestDTO;
 import com.onenth.OneNth.domain.member.dto.MemberResponseDTO;
 import com.onenth.OneNth.domain.member.service.memberService.MemberCommandService;
 import com.onenth.OneNth.global.apiPayload.ApiResponse;
+import com.onenth.OneNth.global.auth.annotation.AuthUser;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -53,4 +52,5 @@ public class MemberRestController {
     public ApiResponse<MemberResponseDTO.LoginResultDTO> login(@RequestBody @Valid MemberRequestDTO.LoginRequestDTO request) {
         return ApiResponse.onSuccess(memberCommandService.loginMember(request));
     }
+
 }

--- a/src/main/java/com/onenth/OneNth/domain/member/controller/MemberRestController.java
+++ b/src/main/java/com/onenth/OneNth/domain/member/controller/MemberRestController.java
@@ -4,6 +4,10 @@ import com.onenth.OneNth.domain.member.dto.MemberRequestDTO;
 import com.onenth.OneNth.domain.member.dto.MemberResponseDTO;
 import com.onenth.OneNth.domain.member.service.memberService.MemberCommandService;
 import com.onenth.OneNth.global.apiPayload.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -18,13 +22,33 @@ public class MemberRestController {
 
     private final MemberCommandService memberCommandService;
 
-    // 일반 회원가입 API 구현
+    /**
+     * 일반 회원가입 API 구현
+     */
+    @Operation(
+            summary = "일반 회원가입 API",
+            description = "일반 회원가입을 진행합니다. 이메일 인증 후 회원 정보를 보내주세요."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "잘못된 요청입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+    })
     @PostMapping("/signup")
     public ApiResponse<MemberResponseDTO.SignupResultDTO> signup(@RequestBody @Valid MemberRequestDTO.SignupDTO request) {
         return ApiResponse.onSuccess(memberCommandService.signupMember(request));
     }
 
-    // 일반 로그인 API 구현
+    /**
+     * 일반 로그인 API 구현
+     */
+    @Operation(
+            summary = "일반 로그인 API",
+            description = "일반 로그인을 진행합니다. 응답으로 JWT 토큰이 발급됩니다. 헤더에 담아서 사용하세요."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "잘못된 요청입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+    })
     @PostMapping("/login")
     public ApiResponse<MemberResponseDTO.LoginResultDTO> login(@RequestBody @Valid MemberRequestDTO.LoginRequestDTO request) {
         return ApiResponse.onSuccess(memberCommandService.loginMember(request));

--- a/src/main/java/com/onenth/OneNth/domain/member/controller/MemberRestController.java
+++ b/src/main/java/com/onenth/OneNth/domain/member/controller/MemberRestController.java
@@ -1,0 +1,25 @@
+package com.onenth.OneNth.domain.member.controller;
+
+import com.onenth.OneNth.domain.member.dto.MemberRequestDTO;
+import com.onenth.OneNth.domain.member.dto.MemberResponseDTO;
+import com.onenth.OneNth.domain.member.service.memberService.MemberCommandService;
+import com.onenth.OneNth.global.apiPayload.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/members")
+public class MemberRestController {
+
+    private final MemberCommandService memberCommandService;
+
+    @PostMapping("/signup")
+    public ApiResponse<MemberResponseDTO.SignupResultDTO> signup(@RequestBody @Valid MemberRequestDTO.SignupDTO request) {
+        return ApiResponse.onSuccess(memberCommandService.signupMember(request));
+    }
+}

--- a/src/main/java/com/onenth/OneNth/domain/member/controller/MemberRestController.java
+++ b/src/main/java/com/onenth/OneNth/domain/member/controller/MemberRestController.java
@@ -18,8 +18,15 @@ public class MemberRestController {
 
     private final MemberCommandService memberCommandService;
 
+    // 일반 회원가입 API 구현
     @PostMapping("/signup")
     public ApiResponse<MemberResponseDTO.SignupResultDTO> signup(@RequestBody @Valid MemberRequestDTO.SignupDTO request) {
         return ApiResponse.onSuccess(memberCommandService.signupMember(request));
+    }
+
+    // 일반 로그인 API 구현
+    @PostMapping("/login")
+    public ApiResponse<MemberResponseDTO.LoginResultDTO> login(@RequestBody @Valid MemberRequestDTO.LoginRequestDTO request) {
+        return ApiResponse.onSuccess(memberCommandService.loginMember(request));
     }
 }

--- a/src/main/java/com/onenth/OneNth/domain/member/converter/MemberConverter.java
+++ b/src/main/java/com/onenth/OneNth/domain/member/converter/MemberConverter.java
@@ -22,6 +22,7 @@ public class MemberConverter {
                 .birthday(request.getBirthday())
                 .loginType(LoginType.NORMAL)
                 .memberRegions(new ArrayList<>())
+                .marketingAgree(request.getMarketingAgree())
                 .build();
 
         //회원가입시에는 지역 한개만 매핑

--- a/src/main/java/com/onenth/OneNth/domain/member/converter/MemberConverter.java
+++ b/src/main/java/com/onenth/OneNth/domain/member/converter/MemberConverter.java
@@ -1,0 +1,45 @@
+package com.onenth.OneNth.domain.member.converter;
+
+import com.onenth.OneNth.domain.member.dto.MemberRequestDTO;
+import com.onenth.OneNth.domain.member.dto.MemberResponseDTO;
+import com.onenth.OneNth.domain.member.entity.Member;
+import com.onenth.OneNth.domain.member.entity.MemberRegion;
+import com.onenth.OneNth.domain.member.entity.enums.LoginType;
+import com.onenth.OneNth.domain.region.entity.Region;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+
+public class MemberConverter {
+
+    //회원가입 요청 dto 를 Member 엔티티로 변환
+    public static Member toMember(MemberRequestDTO.SignupDTO request, Region region) {
+        Member member = Member.builder()
+                .name(request.getName())
+                .email(request.getEmail())
+                .password(request.getPassword())
+                .nickname(request.getNickname())
+                .birthday(request.getBirthday())
+                .loginType(LoginType.NORMAL)
+                .memberRegions(new ArrayList<>())
+                .build();
+
+        //회원가입시에는 지역 한개만 매핑
+        MemberRegion memberRegion = MemberRegion.builder()
+                .member(member)
+                .region(region)
+                .build();
+
+        member.getMemberRegions().add(memberRegion);
+
+        return member;
+    }
+
+    // Member 엔티티를 회원가입 응답 dto 로 변환
+    public static MemberResponseDTO.SignupResultDTO toSignupResultDTO(Member member) {
+        return MemberResponseDTO.SignupResultDTO.builder()
+                .memberId(member.getId())
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
+}

--- a/src/main/java/com/onenth/OneNth/domain/member/converter/MemberConverter.java
+++ b/src/main/java/com/onenth/OneNth/domain/member/converter/MemberConverter.java
@@ -19,7 +19,6 @@ public class MemberConverter {
                 .email(request.getEmail())
                 .password(request.getPassword())
                 .nickname(request.getNickname())
-                .birthday(request.getBirthday())
                 .loginType(LoginType.NORMAL)
                 .memberRegions(new ArrayList<>())
                 .marketingAgree(request.getMarketingAgree())
@@ -42,5 +41,13 @@ public class MemberConverter {
                 .memberId(member.getId())
                 .createdAt(LocalDateTime.now())
                 .build();
+    }
+
+    //로그인 결과 dto로 변환
+    public static MemberResponseDTO.LoginResultDTO toLoginResultDTO(Long memberId, String accessToken) {
+       return MemberResponseDTO.LoginResultDTO.builder()
+               .memberId(memberId)
+               .accessToken(accessToken)
+               .build();
     }
 }

--- a/src/main/java/com/onenth/OneNth/domain/member/dto/MemberRequestDTO.java
+++ b/src/main/java/com/onenth/OneNth/domain/member/dto/MemberRequestDTO.java
@@ -1,0 +1,35 @@
+package com.onenth.OneNth.domain.member.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+public class MemberRequestDTO {
+
+    // 회원가입 요청 dto
+    @Getter
+    public static class SignupDTO{
+        @NotBlank
+        String name;
+
+        @Email
+        @NotBlank
+        String email;
+
+        @NotBlank
+        String password;
+
+        @NotBlank
+        String nickname;
+
+        @NotBlank
+        String regionName;
+
+        @NotNull
+        private LocalDate birthday;
+
+    }
+}

--- a/src/main/java/com/onenth/OneNth/domain/member/dto/MemberRequestDTO.java
+++ b/src/main/java/com/onenth/OneNth/domain/member/dto/MemberRequestDTO.java
@@ -9,6 +9,25 @@ import java.time.LocalDate;
 
 public class MemberRequestDTO {
 
+    //이메일 인증 코드 요청 dto
+    @Getter
+    public static class EmailCodeRequestDTO {
+        @Email
+        @NotBlank
+        private String email;
+    }
+
+    //인증 코드 검증 요청 dto
+    @Getter
+    public static class VerifyCodeRequestDTO {
+        @Email
+        @NotBlank
+        private String email;
+
+        @NotBlank
+        private String code;
+    }
+
     // 회원가입 요청 dto
     @Getter
     public static class SignupDTO{
@@ -30,6 +49,9 @@ public class MemberRequestDTO {
 
         @NotNull
         private LocalDate birthday;
+
+        @NotNull
+        private Boolean marketingAgree;
 
     }
 }

--- a/src/main/java/com/onenth/OneNth/domain/member/dto/MemberRequestDTO.java
+++ b/src/main/java/com/onenth/OneNth/domain/member/dto/MemberRequestDTO.java
@@ -44,6 +44,9 @@ public class MemberRequestDTO {
         private String password;
 
         @NotBlank
+        private String confirmPassword;
+
+        @NotBlank
         private String nickname;
 
         @NotBlank

--- a/src/main/java/com/onenth/OneNth/domain/member/dto/MemberRequestDTO.java
+++ b/src/main/java/com/onenth/OneNth/domain/member/dto/MemberRequestDTO.java
@@ -4,6 +4,8 @@ import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
+import lombok.Setter;
+import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
 
@@ -34,24 +36,36 @@ public class MemberRequestDTO {
         @NotBlank
         String name;
 
-        @Email
-        @NotBlank
-        String email;
+        @NotBlank(message = "이메일은 필수입니다.")
+        @Email(message = "올바른 이메일 형식이어야 합니다.")
+        private String email;
 
         @NotBlank
-        String password;
+        private String password;
 
         @NotBlank
-        String nickname;
+        private String nickname;
 
         @NotBlank
-        String regionName;
+        private String regionName;
 
-        @NotNull
-        private LocalDate birthday;
+//        @NotNull
+//        private LocalDate birthday;
 
         @NotNull
         private Boolean marketingAgree;
 
+    }
+
+    // 로그인 요청 dto
+    @Getter
+    @Setter
+    public static class LoginRequestDTO {
+        @NotBlank(message = "이메일은 필수입니다.")
+        @Email(message = "올바른 이메일 형식이어야 합니다.")
+        private String email;
+
+        @NotBlank(message = "패스워드는 필수입니다.")
+        private String password;
     }
 }

--- a/src/main/java/com/onenth/OneNth/domain/member/dto/MemberResponseDTO.java
+++ b/src/main/java/com/onenth/OneNth/domain/member/dto/MemberResponseDTO.java
@@ -17,4 +17,13 @@ public class MemberResponseDTO {
         Long memberId;
         LocalDateTime createdAt;
     }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class LoginResultDTO {
+        Long memberId;
+        String accessToken;
+    }
 }

--- a/src/main/java/com/onenth/OneNth/domain/member/dto/MemberResponseDTO.java
+++ b/src/main/java/com/onenth/OneNth/domain/member/dto/MemberResponseDTO.java
@@ -1,0 +1,20 @@
+package com.onenth.OneNth.domain.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+public class MemberResponseDTO {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class SignupResultDTO {
+        Long memberId;
+        LocalDateTime createdAt;
+    }
+}

--- a/src/main/java/com/onenth/OneNth/domain/member/entity/EmailVerificationCode.java
+++ b/src/main/java/com/onenth/OneNth/domain/member/entity/EmailVerificationCode.java
@@ -1,0 +1,39 @@
+package com.onenth.OneNth.domain.member.entity;
+
+import com.onenth.OneNth.domain.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class EmailVerificationCode extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String email;
+
+    private String code;
+
+    private LocalDateTime expiresAt;
+
+    private boolean isVerified = false;
+
+    public boolean isExpired() {
+        return LocalDateTime.now().isAfter(expiresAt);
+    }
+
+    public void markVerified() {
+        this.isVerified = true;
+    }
+
+}

--- a/src/main/java/com/onenth/OneNth/domain/member/entity/Member.java
+++ b/src/main/java/com/onenth/OneNth/domain/member/entity/Member.java
@@ -26,6 +26,9 @@ public class Member extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(length=10, nullable=false)
+    private String name;
+
     @Column(length=254, nullable=false, unique = true)
     private String email;
 
@@ -42,11 +45,13 @@ public class Member extends BaseEntity {
     @Column(nullable = false)
     private LoginType loginType;
 
-    @Column(nullable=false)
-    private boolean marketingAgree = false;
+    private LocalDate inactiveDate;
 
-    @OneToOne(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
-    private MemberRegion memberRegion;
+//    @Column(nullable=false)
+//    private boolean marketingAgree = false;
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<MemberRegion> memberRegions = new ArrayList<>();
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Alert> alerts = new ArrayList<>();
@@ -68,4 +73,8 @@ public class Member extends BaseEntity {
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<PurchaseItem> purchaseItems = new ArrayList<>();
+
+    public void encodePassword(String password) {
+        this.password = password;
+    }
 }

--- a/src/main/java/com/onenth/OneNth/domain/member/entity/Member.java
+++ b/src/main/java/com/onenth/OneNth/domain/member/entity/Member.java
@@ -38,8 +38,8 @@ public class Member extends BaseEntity {
     @Column(length=10, nullable=false)
     private String nickname;
 
-    @Column(nullable=false)
-    private LocalDate birthday;
+//    @Column(nullable=false)
+//    private LocalDate birthday;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)

--- a/src/main/java/com/onenth/OneNth/domain/member/entity/Member.java
+++ b/src/main/java/com/onenth/OneNth/domain/member/entity/Member.java
@@ -47,8 +47,13 @@ public class Member extends BaseEntity {
 
     private LocalDate inactiveDate;
 
-//    @Column(nullable=false)
-//    private boolean marketingAgree = false;
+    @Column(nullable=false)
+    private boolean marketingAgree = false;
+
+    //비밀번호 salt 암호화 메서드
+    public void encodePassword(String password) {
+        this.password = password;
+    }
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<MemberRegion> memberRegions = new ArrayList<>();
@@ -74,7 +79,4 @@ public class Member extends BaseEntity {
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<PurchaseItem> purchaseItems = new ArrayList<>();
 
-    public void encodePassword(String password) {
-        this.password = password;
-    }
 }

--- a/src/main/java/com/onenth/OneNth/domain/member/entity/MemberRegion.java
+++ b/src/main/java/com/onenth/OneNth/domain/member/entity/MemberRegion.java
@@ -20,7 +20,7 @@ public class MemberRegion extends BaseEntity {
     @JoinColumn(name = "region_id", nullable = false)
     private Region region;
 
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 }

--- a/src/main/java/com/onenth/OneNth/domain/member/repository/emailVerificationTokenRepository/EmailVerificationCodeRepository.java
+++ b/src/main/java/com/onenth/OneNth/domain/member/repository/emailVerificationTokenRepository/EmailVerificationCodeRepository.java
@@ -1,0 +1,14 @@
+package com.onenth.OneNth.domain.member.repository.emailVerificationTokenRepository;
+
+import com.onenth.OneNth.domain.member.entity.EmailVerificationCode;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface EmailVerificationCodeRepository extends JpaRepository<EmailVerificationCode, Long> {
+    Optional<EmailVerificationCode> findTopByEmailOrderByExpiresAtDesc(String email);
+
+    boolean existsByEmail(String email);
+}

--- a/src/main/java/com/onenth/OneNth/domain/member/repository/memberRepository/MemberRepository.java
+++ b/src/main/java/com/onenth/OneNth/domain/member/repository/memberRepository/MemberRepository.java
@@ -3,6 +3,10 @@ package com.onenth.OneNth.domain.member.repository.memberRepository;
 import com.onenth.OneNth.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface MemberRepository extends JpaRepository<Member, Long>, MemberRepositoryCustom {
     boolean existsByEmail(String email);
+
+    Optional<Member> findByEmail(String email);
 }

--- a/src/main/java/com/onenth/OneNth/domain/member/repository/memberRepository/MemberRepository.java
+++ b/src/main/java/com/onenth/OneNth/domain/member/repository/memberRepository/MemberRepository.java
@@ -4,4 +4,5 @@ import com.onenth.OneNth.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member, Long>, MemberRepositoryCustom {
+    boolean existsByEmail(String email);
 }

--- a/src/main/java/com/onenth/OneNth/domain/member/repository/memberRepository/MemberRepository.java
+++ b/src/main/java/com/onenth/OneNth/domain/member/repository/memberRepository/MemberRepository.java
@@ -1,0 +1,7 @@
+package com.onenth.OneNth.domain.member.repository.memberRepository;
+
+import com.onenth.OneNth.domain.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long>, MemberRepositoryCustom {
+}

--- a/src/main/java/com/onenth/OneNth/domain/member/repository/memberRepository/MemberRepositoryCustom.java
+++ b/src/main/java/com/onenth/OneNth/domain/member/repository/memberRepository/MemberRepositoryCustom.java
@@ -1,0 +1,4 @@
+package com.onenth.OneNth.domain.member.repository.memberRepository;
+
+public interface MemberRepositoryCustom {
+}

--- a/src/main/java/com/onenth/OneNth/domain/member/repository/memberRepository/MemberRepositoryImpl.java
+++ b/src/main/java/com/onenth/OneNth/domain/member/repository/memberRepository/MemberRepositoryImpl.java
@@ -1,0 +1,10 @@
+package com.onenth.OneNth.domain.member.repository.memberRepository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class MemberRepositoryImpl implements MemberRepositoryCustom{
+
+}

--- a/src/main/java/com/onenth/OneNth/domain/member/service/EmailVerificationService/EmailService.java
+++ b/src/main/java/com/onenth/OneNth/domain/member/service/EmailVerificationService/EmailService.java
@@ -1,0 +1,27 @@
+package com.onenth.OneNth.domain.member.service.EmailVerificationService;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class EmailService {
+
+    private final JavaMailSender mailSender;
+
+    public void sendVerificationEmail(String to, String code) {
+        String subject = "[N분의1] 이메일 인증번호입니다.";
+        String content = "인증번호는 다음과 같습니다.\n" + code + "\n 코드 유효시간은 5분입니다.";
+
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo(to);
+        message.setSubject(subject);
+        message.setText(content);
+
+        mailSender.send(message);
+    }
+
+
+}

--- a/src/main/java/com/onenth/OneNth/domain/member/service/EmailVerificationService/EmailService.java
+++ b/src/main/java/com/onenth/OneNth/domain/member/service/EmailVerificationService/EmailService.java
@@ -13,7 +13,7 @@ public class EmailService {
 
     public void sendVerificationEmail(String to, String code) {
         String subject = "[N분의1] 이메일 인증번호입니다.";
-        String content = "인증번호는 다음과 같습니다.\n" + code + "\n 코드 유효시간은 5분입니다.";
+        String content = "**인증번호는 다음과 같습니다.**\n" + code + "\n **코드 유효시간은 5분입니다.**";
 
         SimpleMailMessage message = new SimpleMailMessage();
         message.setTo(to);

--- a/src/main/java/com/onenth/OneNth/domain/member/service/EmailVerificationService/EmailVerificationService.java
+++ b/src/main/java/com/onenth/OneNth/domain/member/service/EmailVerificationService/EmailVerificationService.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
 import java.util.UUID;
+import java.util.regex.Pattern;
 
 @Service
 @RequiredArgsConstructor
@@ -17,11 +18,17 @@ public class EmailVerificationService {
     private final EmailVerificationCodeRepository codeRepository;
     private final EmailService emailService;
     private final MemberRepository memberRepository;
-
+    private static final Pattern EMAIL_PATTERN = Pattern.compile(
+            "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$"
+    );
     public void sendCode(String email) {
+        if (!EMAIL_PATTERN.matcher(email).matches()) {
+            throw new RuntimeException("올바르지 않은 이메일 형식입니다.");
+        }
+
         if (memberRepository.existsByEmail(email)) {
             // 이메일 중복 검증 (회원가입 DB와 연결 필요)
-            throw new IllegalArgumentException("이미 가입된 이메일입니다.");
+            throw new RuntimeException("이미 가입된 이메일입니다.");
         }
 
         String code = generateCode();

--- a/src/main/java/com/onenth/OneNth/domain/member/service/EmailVerificationService/EmailVerificationService.java
+++ b/src/main/java/com/onenth/OneNth/domain/member/service/EmailVerificationService/EmailVerificationService.java
@@ -1,0 +1,67 @@
+package com.onenth.OneNth.domain.member.service.EmailVerificationService;
+
+import com.onenth.OneNth.domain.member.entity.EmailVerificationCode;
+import com.onenth.OneNth.domain.member.entity.Member;
+import com.onenth.OneNth.domain.member.repository.emailVerificationTokenRepository.EmailVerificationCodeRepository;
+import com.onenth.OneNth.domain.member.repository.memberRepository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class EmailVerificationService {
+
+    private final EmailVerificationCodeRepository codeRepository;
+    private final EmailService emailService;
+    private final MemberRepository memberRepository;
+
+    public void sendCode(String email) {
+        if (memberRepository.existsByEmail(email)) {
+            // 이메일 중복 검증 (회원가입 DB와 연결 필요)
+            throw new IllegalArgumentException("이미 가입된 이메일입니다.");
+        }
+
+        String code = generateCode();
+
+        EmailVerificationCode emailVerificationCode = EmailVerificationCode.builder()
+                .email(email)
+                .code(code)
+                .expiresAt(LocalDateTime.now().plusMinutes(5))
+                .isVerified(false)
+                .build();
+
+        codeRepository.save(emailVerificationCode);
+        emailService.sendVerificationEmail(email, code);
+    }
+
+    public void verifyCode(String email, String code) {
+        //검증할 타겟 코드 불러오기
+        EmailVerificationCode targetCode = codeRepository.findTopByEmailOrderByExpiresAtDesc(email)
+                .orElseThrow(() -> new RuntimeException("인증 요청이 없습니다."));
+
+        //유효시간이 남아있는지 검증
+        if (targetCode.isExpired()) { throw new RuntimeException("인증번호가 만료되었습니다."); }
+
+        //입력한 코드가 타겟 코드와 같은지 검증
+        if (!targetCode.getCode().equals(code)) { throw new RuntimeException("인증번호가 일치하지 않습니다."); }
+
+        //검증됨 으로 타겟코드 변경
+        targetCode.markVerified();
+
+        //변경사항 저장
+        codeRepository.save(targetCode);
+    }
+
+    public String generateCode() {
+        return String.valueOf((int)(Math.random() * 900000) + 100000);
+    }
+
+    public boolean isVerified(String email) {
+        return codeRepository.findTopByEmailOrderByExpiresAtDesc(email)
+                .map(EmailVerificationCode::isVerified)
+                .orElse(false);
+    }
+}

--- a/src/main/java/com/onenth/OneNth/domain/member/service/memberService/MemberCommandService.java
+++ b/src/main/java/com/onenth/OneNth/domain/member/service/memberService/MemberCommandService.java
@@ -1,0 +1,16 @@
+package com.onenth.OneNth.domain.member.service.memberService;
+
+import com.onenth.OneNth.domain.member.dto.MemberRequestDTO;
+import com.onenth.OneNth.domain.member.dto.MemberResponseDTO;
+import com.onenth.OneNth.domain.member.entity.Member;
+import com.onenth.OneNth.domain.member.repository.memberRepository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+
+public interface MemberCommandService {
+
+    //회원가입 로직 구현
+    MemberResponseDTO.SignupResultDTO signupMember(MemberRequestDTO.SignupDTO request);
+
+}

--- a/src/main/java/com/onenth/OneNth/domain/member/service/memberService/MemberCommandService.java
+++ b/src/main/java/com/onenth/OneNth/domain/member/service/memberService/MemberCommandService.java
@@ -13,4 +13,6 @@ public interface MemberCommandService {
     //회원가입 로직 구현
     MemberResponseDTO.SignupResultDTO signupMember(MemberRequestDTO.SignupDTO request);
 
+    //일반로그인 로직 구현
+    MemberResponseDTO.LoginResultDTO loginMember(MemberRequestDTO.LoginRequestDTO request);
 }

--- a/src/main/java/com/onenth/OneNth/domain/member/service/memberService/MemberCommandServiceImpl.java
+++ b/src/main/java/com/onenth/OneNth/domain/member/service/memberService/MemberCommandServiceImpl.java
@@ -3,8 +3,11 @@ package com.onenth.OneNth.domain.member.service.memberService;
 import com.onenth.OneNth.domain.member.converter.MemberConverter;
 import com.onenth.OneNth.domain.member.dto.MemberRequestDTO;
 import com.onenth.OneNth.domain.member.dto.MemberResponseDTO;
+import com.onenth.OneNth.domain.member.entity.EmailVerificationCode;
 import com.onenth.OneNth.domain.member.entity.Member;
 import com.onenth.OneNth.domain.member.repository.memberRepository.MemberRepository;
+import com.onenth.OneNth.domain.member.service.EmailVerificationService.EmailService;
+import com.onenth.OneNth.domain.member.service.EmailVerificationService.EmailVerificationService;
 import com.onenth.OneNth.domain.region.entity.Region;
 import com.onenth.OneNth.domain.region.repository.RegionRepository;
 import lombok.RequiredArgsConstructor;
@@ -18,9 +21,16 @@ public class MemberCommandServiceImpl implements MemberCommandService {
     private final MemberRepository memberRepository;
     private final RegionRepository regionRepository;
     private final PasswordEncoder passwordEncoder;
+    private final EmailVerificationService emailVerificationService;
+    private final EmailService emailService;
 
     @Override
     public MemberResponseDTO.SignupResultDTO signupMember(MemberRequestDTO.SignupDTO request) {
+
+        //이메일 인증 여부 우선 확인
+        if (!emailVerificationService.isVerified(request.getEmail())) {
+            throw new RuntimeException("이메일 인증을 먼저 완료해주세요");
+        }
         // 1. 지역명으로 Region 조회
         Region region = regionRepository.findByRegionName(request.getRegionName())
                 .orElseThrow(() -> new RuntimeException("해당 지역이 존재하지 않습니다."));
@@ -31,7 +41,7 @@ public class MemberCommandServiceImpl implements MemberCommandService {
         //3. 비밀번호 암호화
         member.encodePassword(passwordEncoder.encode(request.getPassword()));
 
-        // 4. 저장
+        //4. 회원 저장
         return MemberConverter.toSignupResultDTO(memberRepository.save(member));
     }
 }

--- a/src/main/java/com/onenth/OneNth/domain/member/service/memberService/MemberCommandServiceImpl.java
+++ b/src/main/java/com/onenth/OneNth/domain/member/service/memberService/MemberCommandServiceImpl.java
@@ -1,0 +1,37 @@
+package com.onenth.OneNth.domain.member.service.memberService;
+
+import com.onenth.OneNth.domain.member.converter.MemberConverter;
+import com.onenth.OneNth.domain.member.dto.MemberRequestDTO;
+import com.onenth.OneNth.domain.member.dto.MemberResponseDTO;
+import com.onenth.OneNth.domain.member.entity.Member;
+import com.onenth.OneNth.domain.member.repository.memberRepository.MemberRepository;
+import com.onenth.OneNth.domain.region.entity.Region;
+import com.onenth.OneNth.domain.region.repository.RegionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MemberCommandServiceImpl implements MemberCommandService {
+
+    private final MemberRepository memberRepository;
+    private final RegionRepository regionRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Override
+    public MemberResponseDTO.SignupResultDTO signupMember(MemberRequestDTO.SignupDTO request) {
+        // 1. 지역명으로 Region 조회
+        Region region = regionRepository.findByRegionName(request.getRegionName())
+                .orElseThrow(() -> new RuntimeException("해당 지역이 존재하지 않습니다."));
+
+        // 2. Member + MemberRegion 생성
+        Member member = MemberConverter.toMember(request, region);
+
+        //3. 비밀번호 암호화
+        member.encodePassword(passwordEncoder.encode(request.getPassword()));
+
+        // 4. 저장
+        return MemberConverter.toSignupResultDTO(memberRepository.save(member));
+    }
+}

--- a/src/main/java/com/onenth/OneNth/domain/member/service/memberService/MemberCommandServiceImpl.java
+++ b/src/main/java/com/onenth/OneNth/domain/member/service/memberService/MemberCommandServiceImpl.java
@@ -61,7 +61,8 @@ public class MemberCommandServiceImpl implements MemberCommandService {
         }
 
         Authentication authentication = new UsernamePasswordAuthenticationToken(
-                member.getEmail(), null,
+                member.getId().toString(),
+                null,
                 Collections.emptyList()
         );
 

--- a/src/main/java/com/onenth/OneNth/domain/member/service/memberService/MemberCommandServiceImpl.java
+++ b/src/main/java/com/onenth/OneNth/domain/member/service/memberService/MemberCommandServiceImpl.java
@@ -37,17 +37,23 @@ public class MemberCommandServiceImpl implements MemberCommandService {
         if (!emailVerificationService.isVerified(request.getEmail())) {
             throw new RuntimeException("이메일 인증을 먼저 완료해주세요");
         }
-        // 1. 지역명으로 Region 조회
+
+        // 1. Password 와 confirmPassword 값 일치 확인
+        if (!request.getPassword().equals(request.getConfirmPassword())) {
+            throw new RuntimeException("Password 와 ConfirmPassword 의 값이 일치하지 않습니다.");
+        }
+
+        // 2. 지역명으로 Region 조회
         Region region = regionRepository.findByRegionName(request.getRegionName())
                 .orElseThrow(() -> new RuntimeException("해당 지역이 존재하지 않습니다."));
 
-        // 2. Member + MemberRegion 생성
+        // 3. Member + MemberRegion 생성
         Member member = MemberConverter.toMember(request, region);
 
-        //3. 비밀번호 암호화
+        // 4. 비밀번호 암호화
         member.encodePassword(passwordEncoder.encode(request.getPassword()));
 
-        //4. 회원 저장
+        // 5. 회원 저장
         return MemberConverter.toSignupResultDTO(memberRepository.save(member));
     }
 

--- a/src/main/java/com/onenth/OneNth/domain/member/service/memberService/MemberQueryService.java
+++ b/src/main/java/com/onenth/OneNth/domain/member/service/memberService/MemberQueryService.java
@@ -1,0 +1,4 @@
+package com.onenth.OneNth.domain.member.service.memberService;
+
+public interface MemberQueryService {
+}

--- a/src/main/java/com/onenth/OneNth/domain/member/service/memberService/MemberQueryServiceImpl.java
+++ b/src/main/java/com/onenth/OneNth/domain/member/service/memberService/MemberQueryServiceImpl.java
@@ -1,0 +1,9 @@
+package com.onenth.OneNth.domain.member.service.memberService;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class MemberQueryServiceImpl implements MemberQueryService {
+}

--- a/src/main/java/com/onenth/OneNth/domain/region/entity/Region.java
+++ b/src/main/java/com/onenth/OneNth/domain/region/entity/Region.java
@@ -15,5 +15,6 @@ public class Region extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Integer id;
 
+    @Column(nullable = false, unique = true)
     private String regionName;
 }

--- a/src/main/java/com/onenth/OneNth/domain/region/repository/RegionRepository.java
+++ b/src/main/java/com/onenth/OneNth/domain/region/repository/RegionRepository.java
@@ -1,0 +1,13 @@
+package com.onenth.OneNth.domain.region.repository;
+
+import com.onenth.OneNth.domain.region.entity.Region;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface RegionRepository extends JpaRepository<Region, Long> {
+
+    Optional<Region> findByRegionName (String regionName);
+}

--- a/src/main/java/com/onenth/OneNth/global/auth/annotation/AuthUser.java
+++ b/src/main/java/com/onenth/OneNth/global/auth/annotation/AuthUser.java
@@ -1,0 +1,9 @@
+package com.onenth.OneNth.global.auth.annotation;
+
+import java.lang.annotation.*;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface AuthUser {
+}

--- a/src/main/java/com/onenth/OneNth/global/auth/resolver/AuthUserArgumentResolver.java
+++ b/src/main/java/com/onenth/OneNth/global/auth/resolver/AuthUserArgumentResolver.java
@@ -1,0 +1,47 @@
+package com.onenth.OneNth.global.auth.resolver;
+
+import com.onenth.OneNth.global.auth.annotation.AuthUser;
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+public class AuthUserArgumentResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(AuthUser.class) &&
+                parameter.getParameterType().equals(Long.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication == null || !authentication.isAuthenticated()) {
+            return null; // 또는 throw new UnauthenticatedException();
+        }
+
+        // principal로부터 userId 꺼내기 (너가 토큰에 어떻게 담았는지에 따라 다름)
+        Object principal = authentication.getPrincipal();
+
+        if (principal instanceof UserDetails userDetails) {
+            return Long.valueOf(userDetails.getUsername()); // username 대신 id를 넣었다면
+        }
+
+        // 혹시 email이 아니라 id 자체를 직접 토큰 subject에 넣었다면
+        if (principal instanceof org.springframework.security.core.userdetails.User user) {
+            return Long.valueOf(user.getUsername()); // string -> long 변환
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/com/onenth/OneNth/global/configuration/WebConfig.java
+++ b/src/main/java/com/onenth/OneNth/global/configuration/WebConfig.java
@@ -1,0 +1,24 @@
+package com.onenth.OneNth.global.configuration;
+
+import com.onenth.OneNth.global.auth.resolver.AuthUserArgumentResolver;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    private final AuthUserArgumentResolver authUserArgumentResolver;
+
+    public WebConfig(AuthUserArgumentResolver resolver) {
+        this.authUserArgumentResolver = resolver;
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(authUserArgumentResolver);
+    }
+}

--- a/src/main/java/com/onenth/OneNth/global/configuration/properties/JwtProperties.java
+++ b/src/main/java/com/onenth/OneNth/global/configuration/properties/JwtProperties.java
@@ -1,0 +1,25 @@
+package com.onenth.OneNth.global.configuration.properties;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.stereotype.Component;
+
+@Component
+@Getter
+@Setter
+@ConfigurationProperties("jwt.token")
+public class JwtProperties {
+    private String secretKey = "";
+    private Expiration expiration;
+
+    @Getter
+    @Setter
+    public static class Expiration {
+        private Long access;
+        // TODO: refreshToken
+    }
+
+
+}

--- a/src/main/java/com/onenth/OneNth/global/configuration/security/Constants.java
+++ b/src/main/java/com/onenth/OneNth/global/configuration/security/Constants.java
@@ -1,0 +1,6 @@
+package com.onenth.OneNth.global.configuration.security;
+
+public final class Constants {
+    public static final String AUTH_HEADER = "Authorization";
+    public static final String TOKEN_PREFIX = "Bearer ";
+}

--- a/src/main/java/com/onenth/OneNth/global/configuration/security/CustomUserDetailsService.java
+++ b/src/main/java/com/onenth/OneNth/global/configuration/security/CustomUserDetailsService.java
@@ -1,0 +1,28 @@
+package com.onenth.OneNth.global.configuration.security;
+
+import com.onenth.OneNth.domain.member.entity.Member;
+import com.onenth.OneNth.domain.member.repository.memberRepository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final MemberRepository memberRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        Member member = memberRepository.findByEmail(username)
+                .orElseThrow(() -> new UsernameNotFoundException("해당 이메일을 가진 유저가 존재하지 않습니다. " + username));
+
+        return org.springframework.security.core.userdetails.User
+                .withUsername(member.getEmail())
+                .password(member.getPassword())
+                .build();
+
+    }
+}

--- a/src/main/java/com/onenth/OneNth/global/configuration/security/SecurityConfig.java
+++ b/src/main/java/com/onenth/OneNth/global/configuration/security/SecurityConfig.java
@@ -1,0 +1,30 @@
+package com.onenth.OneNth.global.configuration.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@EnableWebSecurity
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable()) // CSRF 비활성화 (API 서버일 경우)
+                .authorizeHttpRequests(auth -> auth
+                        .anyRequest().permitAll() // 모든 요청 허용
+                );
+
+        return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/onenth/OneNth/global/configuration/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/onenth/OneNth/global/configuration/security/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,43 @@
+package com.onenth.OneNth.global.configuration.security.jwt;
+
+import com.onenth.OneNth.global.configuration.security.Constants;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain)
+            throws ServletException, IOException {
+
+        String token = resolveToken(request);
+
+        if(StringUtils.hasText(token) && jwtTokenProvider.validateToken(token)) {
+            Authentication authentication = jwtTokenProvider.getAuthentication(token);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+        filterChain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader(Constants.AUTH_HEADER);
+        if(StringUtils.hasText(bearerToken) && bearerToken.startsWith(Constants.TOKEN_PREFIX)) {
+            return bearerToken.substring(Constants.TOKEN_PREFIX.length());
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/onenth/OneNth/global/configuration/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/onenth/OneNth/global/configuration/security/jwt/JwtTokenProvider.java
@@ -32,10 +32,10 @@ public class JwtTokenProvider {
 
     //메소드는 인증 정보를 받아서, JWT Access Token을 생성하고 반환
     public String generateToken(Authentication authentication) {
-        String email = authentication.getName();
+        String userId = authentication.getName();
 
         return Jwts.builder()
-                .setSubject(email)
+                .setSubject(userId)
                 .setIssuedAt(new Date())
                 .setExpiration(new Date(System.currentTimeMillis() + jwtProperties.getExpiration().getAccess()))
                 .signWith(getSigningKey(), SignatureAlgorithm.HS256)
@@ -64,9 +64,9 @@ public class JwtTokenProvider {
                 .parseClaimsJws(token)
                 .getBody();
 
-        String email = claims.getSubject();
+        String userId = claims.getSubject();
 
-        User principal = new User(email, "", Collections.emptyList());
+        User principal = new User(userId, "", Collections.emptyList());
         return new UsernamePasswordAuthenticationToken(principal, token, principal.getAuthorities());
     }
 

--- a/src/main/java/com/onenth/OneNth/global/configuration/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/onenth/OneNth/global/configuration/security/jwt/JwtTokenProvider.java
@@ -1,0 +1,95 @@
+package com.onenth.OneNth.global.configuration.security.jwt;
+
+import com.onenth.OneNth.global.configuration.properties.JwtProperties;
+import com.onenth.OneNth.global.configuration.security.Constants;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.security.Key;
+import java.util.Collections;
+import java.util.Date;
+
+@Component
+@RequiredArgsConstructor
+public class JwtTokenProvider {
+
+    private final JwtProperties jwtProperties;
+
+    // 서명키 가져오기
+    private Key getSigningKey() {
+        return Keys.hmacShaKeyFor(jwtProperties.getSecretKey().getBytes());
+    }
+
+    //메소드는 인증 정보를 받아서, JWT Access Token을 생성하고 반환
+    public String generateToken(Authentication authentication) {
+        String email = authentication.getName();
+
+        return Jwts.builder()
+                .setSubject(email)
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + jwtProperties.getExpiration().getAccess()))
+                .signWith(getSigningKey(), SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    // 해당 JWT 토큰이 유효한지 검증해요. 파싱이 된다면 유효한 토큰이고,
+    // 토큰이 만료되었거나 (앞서 저희가 걸었던 4시간 제한을 넘어갔다거나) 혹은 위조, 형식 오류가 생기면 예외가 발생하여 false를 반환
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder()
+                    .setSigningKey(getSigningKey())
+                    .build()
+                    .parseClaimsJws(token);
+            return true;
+        } catch (JwtException | IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+    // JWT 토큰에서 인증 정보를 추출해서, Spring Security의 Authentication 객체로 변환
+    public Authentication getAuthentication(String token) {
+        Claims claims = Jwts.parserBuilder()
+                .setSigningKey(getSigningKey())
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+
+        String email = claims.getSubject();
+
+        User principal = new User(email, "", Collections.emptyList());
+        return new UsernamePasswordAuthenticationToken(principal, token, principal.getAuthorities());
+    }
+
+    // Header에서 값을 읽음, Bearer로 시작하는지 확인하고, Bearer 접두어 제거하고 토큰만 반환
+    public static String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader(Constants.AUTH_HEADER);
+        if(StringUtils.hasText(bearerToken) && bearerToken.startsWith(Constants.TOKEN_PREFIX)) {
+            return bearerToken.substring(Constants.TOKEN_PREFIX.length());
+        }
+        return null;
+    }
+
+    // resolveToken 으로 JWT Access Token 을 꺼냄 validateToken 으로 토큰의 유효성 검증
+    // 토큰이 유효하면 getAuthentication() 을 호출해서 이메일 등 사용자 정보를 꺼내고
+    // Spring Security 의 Authentication 객체로 변환
+    public Authentication extractAuthentication(HttpServletRequest request){
+        String accessToken = resolveToken(request);
+        if(accessToken == null || !validateToken(accessToken)) {
+            throw new RuntimeException("Invalid access token");
+        }
+        return getAuthentication(accessToken);
+    }
+
+
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,7 +6,7 @@ spring:
     driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     show-sql: true
     defer-datasource-initialization: true
     properties:
@@ -29,3 +29,9 @@ spring:
             enable: true
   jackson:
     time-zone: Asia/Seoul
+jwt:
+  token:
+    secretKey: ${JWT_TOKEN_SECRET_KEY}
+    expiration:
+      access: 14400000 # 4시간
+      refresh: 1209600000 # 2주 (예시)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,7 +6,7 @@ spring:
     driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     show-sql: true
     defer-datasource-initialization: true
     properties:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,7 +6,7 @@ spring:
     driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     show-sql: true
     defer-datasource-initialization: true
     properties:
@@ -16,3 +16,16 @@ spring:
         use_sql_comments: true
         jdbc:
           batch_size: 1000
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ${GMAIL_USERNAME}
+    password: ${GMAIL_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+  jackson:
+    time-zone: Asia/Seoul


### PR DESCRIPTION
## 📌 작업 내용
**작업 API 스웨거 명세**
<img width="1036" height="411" alt="swagger_cap" src="https://github.com/user-attachments/assets/48ece15c-5a37-4973-9444-f85786da4721" />

> ### 1. 일반 회원가입 구현
> - 비밀번호 암호화 로직 구현 (BCryptPasswordEncoder) 했습니다.
> - 회원가입을 위한 이메일 인증 로직을 구현하였습니다.

> ### 2. 이메일 코드 인증 구현
> - 회원가입을 위해서는 이메일 인증을 우선 진행해야 합니다. 
> - 이메일 인증을 위한 application.yml 환경변수 설정은 노션의 환경변수 페이지를 참고해주세요.

> ### 3. 일반 로그인 구현
> - JWT 토큰 기반 일반 로그인 기능이 추가되었습니다.
> - Spring Security 설정이 추가되었으므로 토근을 이용한 인가가 필요없는 API 개발 시 SecurityConfig의 securityFilterChain 메서드에 경로를 추가해주세요.
> - 로그인 성공시 memberId와 accessToken이 발급됩니다. 인가에 사용해주세요. 

> ### 4. @AuthUser 추가
> - 현재 사용자의 Id를 주입 받을 수 있는 커스텀 어노테이션을 추가하였습니다. 
> - 사용자 Id가 필요한 API의 컨트롤러에서 사용할 수 있습니다.
> - 사용 예시는 아래와 같습니다.
   ```
    /**
     * 어노테이션 테스트 API
     */

 @GetMapping("/me")
    public ApiResponse<?> getMyPage(@Parameter(hidden = true) @AuthUser Long userId) {
        return ApiResponse.onSuccess("내 ID: " + userId);
    }
```


## ✨ 참고 사항

> 카카오 소셜 로그인은 다른 이슈를 열어서 작업 예정입니다. 우선은 일반로그인을 사용 부탁드립니다.

## 🧩 연관 이슈

> close #1 

<br>