### PR TITLE
✨[Feat] 카카오 소셜 로그인/회원가입 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,13 +40,18 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	testImplementation 'org.springframework.security:spring-security-test'
 
-	//email verification
+	// email verification
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
 
 	//JWT
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+	// spring security OAuth2 클라이언트 의존성
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+
+
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,7 @@ dependencies {
 
 	//AWS
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+    implementation 'com.amazonaws:aws-java-sdk-s3:1.12.696'
 }
 
 tasks.named('test') {

--- a/src/main/generated/com/onenth/OneNth/domain/member/entity/QMember.java
+++ b/src/main/generated/com/onenth/OneNth/domain/member/entity/QMember.java
@@ -57,6 +57,8 @@ public class QMember extends EntityPathBase<Member> {
 
     public final ListPath<com.onenth.OneNth.domain.product.entity.SharingReview, com.onenth.OneNth.domain.product.entity.QSharingReview> sharingReviews = this.<com.onenth.OneNth.domain.product.entity.SharingReview, com.onenth.OneNth.domain.product.entity.QSharingReview>createList("sharingReviews", com.onenth.OneNth.domain.product.entity.SharingReview.class, com.onenth.OneNth.domain.product.entity.QSharingReview.class, PathInits.DIRECT2);
 
+    public final StringPath socialId = createString("socialId");
+
     //inherited
     public final DateTimePath<java.time.LocalDateTime> updatedAt = _super.updatedAt;
 

--- a/src/main/java/com/onenth/OneNth/domain/auth/client/KakaoOAuthClient.java
+++ b/src/main/java/com/onenth/OneNth/domain/auth/client/KakaoOAuthClient.java
@@ -1,4 +1,0 @@
-package com.onenth.OneNth.domain.auth.client;
-
-public class KakaoOAuthClient {
-}

--- a/src/main/java/com/onenth/OneNth/domain/auth/client/KakaoOAuthClient.java
+++ b/src/main/java/com/onenth/OneNth/domain/auth/client/KakaoOAuthClient.java
@@ -1,0 +1,4 @@
+package com.onenth.OneNth.domain.auth.client;
+
+public class KakaoOAuthClient {
+}

--- a/src/main/java/com/onenth/OneNth/domain/auth/controller/KakaoAuthController.java
+++ b/src/main/java/com/onenth/OneNth/domain/auth/controller/KakaoAuthController.java
@@ -41,7 +41,8 @@ public class KakaoAuthController {
      */
     @Operation(
             summary = "카카오 회원가입 요청 API",
-            description = "처음 로그인 시도한 카카오 회원의 회원 정보를 등록하기 위한 API 로 카카오 로그인의 response의 isNew 값이 True 이면 해당 API 요청을 보내야합니다."
+            description = "처음 로그인 시도한 카카오 회원의 회원 정보를 등록하기 위한 API," +
+                    " 카카오 로그인의 응답 isNew 값이 True 이면 해당 API 요청을 보내야합니다."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),

--- a/src/main/java/com/onenth/OneNth/domain/auth/controller/KakaoAuthController.java
+++ b/src/main/java/com/onenth/OneNth/domain/auth/controller/KakaoAuthController.java
@@ -1,0 +1,56 @@
+package com.onenth.OneNth.domain.auth.controller;
+
+import com.onenth.OneNth.domain.auth.dto.KakaoRequestDTO;
+import com.onenth.OneNth.domain.auth.dto.KakaoResponseDTO;
+import com.onenth.OneNth.domain.auth.service.KakaoAuthService;
+import com.onenth.OneNth.global.apiPayload.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "카카오 소셜 로그인/회원가입 API",
+        description = "카카오 소셜 로그인 회원 인가처리 API")
+@RestController
+@RequestMapping("/api/auth/kakao")
+@RequiredArgsConstructor
+public class KakaoAuthController {
+
+    private final KakaoAuthService kakaoAuthService;
+    /**
+     * 카카오 인가 코드를 받는 api
+     */
+    @Operation(
+            summary = "카카오 인가 코드를 받는 API",
+            description = "카카오 로그인을 위해 인가코드를 프론트에서 받습니다. 인가코드로 사용자 정보를 받아서 로그인완료/회원가입 요청으로 분기됩니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "잘못된 요청입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+    })
+    @PostMapping("/login")
+    public ApiResponse<KakaoResponseDTO.KakaoLoginResponseDTO> kakaoCallback(@RequestBody KakaoRequestDTO.KakaoLoginRequestDTO request) {
+        return ApiResponse.onSuccess(kakaoAuthService.processKakaoLogin(request));
+    }
+
+    /**
+     * 카카오 회원가입 api
+     */
+    @Operation(
+            summary = "카카오 회원가입 요청 API",
+            description = "처음 로그인 시도한 카카오 회원의 회원 정보를 등록하기 위한 API 로 카카오 로그인의 response의 isNew 값이 True 이면 해당 API 요청을 보내야합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "잘못된 요청입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+    })
+    @PostMapping("/signup")
+    public ApiResponse<KakaoResponseDTO.KakaoLoginResponseDTO> kakaoSignup(@RequestBody KakaoRequestDTO.KakaoSignupRequestDTO request) {
+        return ApiResponse.onSuccess(kakaoAuthService.signupKakaoMember(request));
+    }
+
+
+}

--- a/src/main/java/com/onenth/OneNth/domain/auth/dto/KakaoRequestDTO.java
+++ b/src/main/java/com/onenth/OneNth/domain/auth/dto/KakaoRequestDTO.java
@@ -1,0 +1,24 @@
+package com.onenth.OneNth.domain.auth.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+public class KakaoRequestDTO {
+
+    @Getter
+    @Setter
+    public static class KakaoLoginRequestDTO {
+        private String code; // 카카오 인가 코드
+    }
+
+    @Getter
+    @Setter
+    public static class KakaoSignupRequestDTO {
+        private String email;
+        private String socialId;
+        private String name;
+        private String nickname;
+        private String regionName;
+        private Boolean marketingAgree;
+    }
+}

--- a/src/main/java/com/onenth/OneNth/domain/auth/dto/KakaoRequestDTO.java
+++ b/src/main/java/com/onenth/OneNth/domain/auth/dto/KakaoRequestDTO.java
@@ -1,5 +1,8 @@
 package com.onenth.OneNth.domain.auth.dto;
 
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -8,17 +11,30 @@ public class KakaoRequestDTO {
     @Getter
     @Setter
     public static class KakaoLoginRequestDTO {
+        @NotBlank(message = "인가코드는 필수입니다.")
         private String code; // 카카오 인가 코드
     }
 
     @Getter
     @Setter
     public static class KakaoSignupRequestDTO {
+        @Email(message = "올바른 이메일 형식이어야 합니다.")
+        @NotBlank(message = "이메일은 필수입니다.")
         private String email;
+
+        @NotBlank(message = "소셜 id는 필수입니다.")
         private String socialId;
+
+        @NotBlank(message = "이름은 필수입니다.")
         private String name;
+
+        @NotBlank(message = "닉네임은 필수입니다.")
         private String nickname;
+
+        @NotBlank(message = "지역명은 필수입니다.")
         private String regionName;
+
+        @NotNull(message = "마케팅 동의 여부는 필수입니다.")
         private Boolean marketingAgree;
     }
 }

--- a/src/main/java/com/onenth/OneNth/domain/auth/dto/KakaoResponseDTO.java
+++ b/src/main/java/com/onenth/OneNth/domain/auth/dto/KakaoResponseDTO.java
@@ -1,0 +1,22 @@
+package com.onenth.OneNth.domain.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class KakaoResponseDTO {
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class KakaoLoginResponseDTO {
+        private String access_token;
+        private String email;
+        private String name;
+        private String serialId;
+        private Boolean isNew; //true 면 회원가입 로직 필요
+    }
+
+}

--- a/src/main/java/com/onenth/OneNth/domain/auth/dto/KakaoUserInfo.java
+++ b/src/main/java/com/onenth/OneNth/domain/auth/dto/KakaoUserInfo.java
@@ -1,0 +1,14 @@
+package com.onenth.OneNth.domain.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class KakaoUserInfo {
+    private String email;
+    // 이름으로 사용
+    private String nickname;
+    // 카카오 사용자 고유 아이디
+    private String id;
+}

--- a/src/main/java/com/onenth/OneNth/domain/auth/dto/KakaoUserInfo.java
+++ b/src/main/java/com/onenth/OneNth/domain/auth/dto/KakaoUserInfo.java
@@ -7,8 +7,6 @@ import lombok.Getter;
 @AllArgsConstructor
 public class KakaoUserInfo {
     private String email;
-    // 이름으로 사용
     private String nickname;
-    // 카카오 사용자 고유 아이디
     private String id;
 }

--- a/src/main/java/com/onenth/OneNth/domain/auth/service/KakaoAuthService.java
+++ b/src/main/java/com/onenth/OneNth/domain/auth/service/KakaoAuthService.java
@@ -1,0 +1,147 @@
+package com.onenth.OneNth.domain.auth.service;
+
+import com.onenth.OneNth.domain.auth.dto.KakaoRequestDTO;
+import com.onenth.OneNth.domain.auth.dto.KakaoResponseDTO;
+import com.onenth.OneNth.domain.auth.dto.KakaoUserInfo;
+import com.onenth.OneNth.domain.member.converter.MemberConverter;
+import com.onenth.OneNth.domain.member.entity.Member;
+import com.onenth.OneNth.domain.member.entity.enums.LoginType;
+import com.onenth.OneNth.domain.member.repository.memberRepository.MemberRepository;
+import com.onenth.OneNth.domain.region.entity.Region;
+import com.onenth.OneNth.domain.region.repository.RegionRepository;
+import com.onenth.OneNth.global.configuration.security.jwt.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+
+
+@Service
+@RequiredArgsConstructor
+public class KakaoAuthService {
+
+    @Value("${kakao.redirect_uri}")
+    private String redirectUri;
+    @Value("${kakao.client_id}")
+    private String clientId;
+
+    private final MemberRepository memberRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final RegionRepository regionRepository;
+
+
+    // 카카오 로그인 요청 처리 서비스
+    public KakaoResponseDTO.KakaoLoginResponseDTO processKakaoLogin (KakaoRequestDTO.KakaoLoginRequestDTO request) {
+        String accessToken = getKakaoAccessToken(request.getCode());
+        KakaoUserInfo userInfo = getUserInfo(accessToken);
+
+        Optional<Member> member = memberRepository.findBySocialIdAndLoginType(userInfo.getId(), LoginType.KAKAO);
+
+        //member 에 객체가 들어있는지 확인
+        if (member.isPresent()) {
+            //이미 가입한적 있다면 로그인 완료
+            Authentication authentication = new UsernamePasswordAuthenticationToken(
+                    member.get().getId(),      // Principal (User Identifier: subject에 들어감)
+                    null,
+                    Collections.emptyList()
+            );
+            String token = jwtTokenProvider.generateToken(authentication);
+
+            return KakaoResponseDTO.KakaoLoginResponseDTO.builder()
+                    .access_token(token)
+                    .isNew(false)
+                    .build();
+        }
+        //기존 가입 정보가 없는 경우 추가 정보 필요
+        else {
+            return KakaoResponseDTO.KakaoLoginResponseDTO.builder()
+                    .email(userInfo.getEmail())
+                    .name(userInfo.getNickname())
+                    .serialId(userInfo.getId())
+                    .isNew(true)
+                    .build();
+        }
+    }
+    // 카카오 회원가입 서비스
+    public KakaoResponseDTO.KakaoLoginResponseDTO signupKakaoMember(KakaoRequestDTO.KakaoSignupRequestDTO request){
+        Region region = regionRepository.findByRegionName(request.getRegionName())
+                .orElseThrow(() -> new RuntimeException("존재하지 않는 지역 이름 입니다."));
+
+        if (memberRepository.existsByEmailAndLoginType(request.getEmail(), LoginType.NORMAL)) {
+            throw new RuntimeException("이미 일반 회원가입을 진행한 사용자입니다.");
+        }
+
+        Member member = MemberConverter.toMember(request, region);
+
+
+        memberRepository.save(member);
+
+        Authentication authentication = new UsernamePasswordAuthenticationToken(
+                member.getId(),
+                null,
+                Collections.emptyList()
+        );
+
+        String token = jwtTokenProvider.generateToken(authentication);
+
+        return KakaoResponseDTO.KakaoLoginResponseDTO.builder()
+                .access_token(token)
+                .isNew(false)
+                .build();
+    }
+
+    //프론트에서 받은 인가 코드로 access token 요청하는 메서드 구현
+    private String getKakaoAccessToken(String authorizationCode) {
+        RestTemplate restTemplate = new RestTemplate();
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("grant_type", "authorization_code");
+        params.add("client_id", clientId);
+        params.add("redirect_uri", redirectUri);
+        params.add("code", authorizationCode);
+
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(params, headers);
+        ResponseEntity<Map> response = restTemplate.postForEntity(
+                "https://kauth.kakao.com/oauth/token",
+                request,
+                Map.class
+        );
+
+        return (String) response.getBody().get("access_token");
+    }
+
+    // 카카오에서 발급받은 access 토큰을 이용해서 사용자 정보 요청하는 메서드
+    private KakaoUserInfo getUserInfo(String accessToken) {
+        RestTemplate restTemplate = new RestTemplate();
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(accessToken);
+
+        HttpEntity<String> request = new HttpEntity<>(headers);
+        ResponseEntity<Map> response = restTemplate.exchange(
+                "https://kapi.kakao.com/v2/user/me",
+                HttpMethod.GET,
+                request,
+                Map.class
+        );
+
+        Map<String, Object> body = response.getBody();
+        Map<String, Object> kakaoAccount = (Map<String, Object>) body.get("kakao_account");
+        Map<String, Object> profile = (Map<String, Object>) kakaoAccount.get("profile");
+
+        return new KakaoUserInfo(
+                (String) kakaoAccount.get("email"),
+                (String) profile.get("nickname"),
+                String.valueOf(body.get("id"))
+        );
+    }
+}

--- a/src/main/java/com/onenth/OneNth/domain/auth/service/KakaoAuthService.java
+++ b/src/main/java/com/onenth/OneNth/domain/auth/service/KakaoAuthService.java
@@ -23,7 +23,6 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 
-
 @Service
 @RequiredArgsConstructor
 public class KakaoAuthService {
@@ -49,7 +48,7 @@ public class KakaoAuthService {
         if (member.isPresent()) {
             //이미 가입한적 있다면 로그인 완료
             Authentication authentication = new UsernamePasswordAuthenticationToken(
-                    member.get().getId(),      // Principal (User Identifier: subject에 들어감)
+                    member.get().getId(),
                     null,
                     Collections.emptyList()
             );
@@ -60,7 +59,7 @@ public class KakaoAuthService {
                     .isNew(false)
                     .build();
         }
-        //기존 가입 정보가 없는 경우 추가 정보 필요
+        //기존 가입 정보가 없는 경우 추가 정보 요청 분기로 넘어감
         else {
             return KakaoResponseDTO.KakaoLoginResponseDTO.builder()
                     .email(userInfo.getEmail())
@@ -76,7 +75,7 @@ public class KakaoAuthService {
                 .orElseThrow(() -> new RuntimeException("존재하지 않는 지역 이름 입니다."));
 
         if (memberRepository.existsByEmailAndLoginType(request.getEmail(), LoginType.NORMAL)) {
-            throw new RuntimeException("이미 일반 회원가입을 진행한 사용자입니다.");
+            throw new RuntimeException("이미 일반 회원가입을 완료한 사용자입니다.");
         }
 
         Member member = MemberConverter.toMember(request, region);
@@ -84,6 +83,7 @@ public class KakaoAuthService {
 
         memberRepository.save(member);
 
+        // 소셜 회원 가입 완료 후 로그인 처리
         Authentication authentication = new UsernamePasswordAuthenticationToken(
                 member.getId(),
                 null,
@@ -98,7 +98,7 @@ public class KakaoAuthService {
                 .build();
     }
 
-    //프론트에서 받은 인가 코드로 access token 요청하는 메서드 구현
+    //프론트에서 받은 인가 코드로 access token 요청하는 메서드
     private String getKakaoAccessToken(String authorizationCode) {
         RestTemplate restTemplate = new RestTemplate();
         HttpHeaders headers = new HttpHeaders();

--- a/src/main/java/com/onenth/OneNth/domain/member/controller/EmailVerificationRestController.java
+++ b/src/main/java/com/onenth/OneNth/domain/member/controller/EmailVerificationRestController.java
@@ -7,12 +7,15 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "E-mail 인증 관련 API",
+        description = "E-mail 인증코드 발송/ 인증코드 검증 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/email-auth")

--- a/src/main/java/com/onenth/OneNth/domain/member/controller/MemberRestController.java
+++ b/src/main/java/com/onenth/OneNth/domain/member/controller/MemberRestController.java
@@ -4,16 +4,17 @@ import com.onenth.OneNth.domain.member.dto.MemberRequestDTO;
 import com.onenth.OneNth.domain.member.dto.MemberResponseDTO;
 import com.onenth.OneNth.domain.member.service.memberService.MemberCommandService;
 import com.onenth.OneNth.global.apiPayload.ApiResponse;
-import com.onenth.OneNth.global.auth.annotation.AuthUser;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "회원 계정 관련 API",
+        description = "일반 로그인/회원가입 계정 찾기 등 계정관리 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/members")

--- a/src/main/java/com/onenth/OneNth/domain/member/controller/MemberRestController.java
+++ b/src/main/java/com/onenth/OneNth/domain/member/controller/MemberRestController.java
@@ -43,7 +43,7 @@ public class MemberRestController {
      */
     @Operation(
             summary = "일반 로그인 API",
-            description = "일반 로그인을 진행합니다. 응답으로 JWT 토큰이 발급됩니다. 헤더에 담아서 사용하세요."
+            description = "일반 로그인을 진행합니다. 응답으로 JWT 토큰이 발급됩니다. 헤더에 담아서 인가에 사용하세요."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),

--- a/src/main/java/com/onenth/OneNth/domain/member/converter/MemberConverter.java
+++ b/src/main/java/com/onenth/OneNth/domain/member/converter/MemberConverter.java
@@ -1,5 +1,6 @@
 package com.onenth.OneNth.domain.member.converter;
 
+import com.onenth.OneNth.domain.auth.dto.KakaoRequestDTO;
 import com.onenth.OneNth.domain.member.dto.MemberRequestDTO;
 import com.onenth.OneNth.domain.member.dto.MemberResponseDTO;
 import com.onenth.OneNth.domain.member.entity.Member;
@@ -30,6 +31,25 @@ public class MemberConverter {
                 .region(region)
                 .build();
 
+        member.getMemberRegions().add(memberRegion);
+
+        return member;
+    }
+
+    //카카오 회원가입 요청 dto 를 Member 엔티티로 변환
+    public static Member toMember(KakaoRequestDTO.KakaoSignupRequestDTO request, Region region) {
+        Member member = Member.builder()
+                .email(request.getEmail())
+                .name(request.getName())
+                .socialId(request.getSocialId())
+                .nickname(request.getNickname())
+                .loginType(LoginType.KAKAO)
+                .memberRegions(new ArrayList<>())
+                .marketingAgree(request.getMarketingAgree())
+                .build();
+
+        //회원가입시에는 지역 한개만 매핑
+        MemberRegion memberRegion = MemberRegion.of(member, region);
         member.getMemberRegions().add(memberRegion);
 
         return member;

--- a/src/main/java/com/onenth/OneNth/domain/member/dto/MemberRequestDTO.java
+++ b/src/main/java/com/onenth/OneNth/domain/member/dto/MemberRequestDTO.java
@@ -14,19 +14,19 @@ public class MemberRequestDTO {
     //이메일 인증 코드 요청 dto
     @Getter
     public static class EmailCodeRequestDTO {
-        @Email
-        @NotBlank
+        @Email(message = "올바른 이메일 형식이어야 합니다.")
+        @NotBlank(message = "이메일은 필수입니다.")
         private String email;
     }
 
     //인증 코드 검증 요청 dto
     @Getter
     public static class VerifyCodeRequestDTO {
-        @Email
-        @NotBlank
+        @Email(message = "올바른 이메일 형식이어야 합니다.")
+        @NotBlank(message = "이메일은 필수입니다.")
         private String email;
 
-        @NotBlank
+        @NotBlank(message = "이메일 검증코드는 필수입니다.")
         private String code;
     }
 
@@ -40,22 +40,22 @@ public class MemberRequestDTO {
         @Email(message = "올바른 이메일 형식이어야 합니다.")
         private String email;
 
-        @NotBlank
+        @NotBlank(message = "비밀번호는 필수입니다.")
         private String password;
 
-        @NotBlank
+        @NotBlank(message = "확인용 비밀번호는 필수입니다.")
         private String confirmPassword;
 
-        @NotBlank
+        @NotBlank(message = "닉네임은 필수입니다.")
         private String nickname;
 
-        @NotBlank
+        @NotBlank(message = "지역명은 필수입니다.")
         private String regionName;
 
 //        @NotNull
 //        private LocalDate birthday;
 
-        @NotNull
+        @NotNull(message = "마케팅 동의 여부는 필수입니다.")
         private Boolean marketingAgree;
 
     }

--- a/src/main/java/com/onenth/OneNth/domain/member/entity/Member.java
+++ b/src/main/java/com/onenth/OneNth/domain/member/entity/Member.java
@@ -32,7 +32,7 @@ public class Member extends BaseEntity {
     @Column(length=254, nullable=false, unique = true)
     private String email;
 
-    @Column(length=300, nullable=false)
+    //@Column(length=300, nullable=false) 소셜로그인은 NULL 가능
     private String password;
 
     @Column(length=10, nullable=false)
@@ -44,6 +44,8 @@ public class Member extends BaseEntity {
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private LoginType loginType;
+
+    private String socialId;
 
     private LocalDate inactiveDate;
 
@@ -57,6 +59,11 @@ public class Member extends BaseEntity {
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<MemberRegion> memberRegions = new ArrayList<>();
+
+    public void addMemberRegion(MemberRegion memberRegion) {
+        this.memberRegions.add(memberRegion);
+        memberRegion.setMember(this);
+    }
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Alert> alerts = new ArrayList<>();

--- a/src/main/java/com/onenth/OneNth/domain/member/entity/MemberRegion.java
+++ b/src/main/java/com/onenth/OneNth/domain/member/entity/MemberRegion.java
@@ -10,6 +10,7 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@Setter
 public class MemberRegion extends BaseEntity {
 
     @Id
@@ -23,4 +24,11 @@ public class MemberRegion extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
+
+    public static MemberRegion of(Member member, Region region) {
+        return MemberRegion.builder()
+                .member(member)
+                .region(region)
+                .build();
+    }
 }

--- a/src/main/java/com/onenth/OneNth/domain/member/repository/memberRepository/MemberRepository.java
+++ b/src/main/java/com/onenth/OneNth/domain/member/repository/memberRepository/MemberRepository.java
@@ -1,6 +1,7 @@
 package com.onenth.OneNth.domain.member.repository.memberRepository;
 
 import com.onenth.OneNth.domain.member.entity.Member;
+import com.onenth.OneNth.domain.member.entity.enums.LoginType;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
@@ -9,4 +10,10 @@ public interface MemberRepository extends JpaRepository<Member, Long>, MemberRep
     boolean existsByEmail(String email);
 
     Optional<Member> findByEmail(String email);
+
+    Optional<Member> findBySocialIdAndLoginType(String socialId, LoginType loginType);
+
+    boolean existsBySocialIdAndLoginType(String socialId, LoginType loginType);
+
+    boolean existsByEmailAndLoginType(String email, LoginType loginType);
 }

--- a/src/main/java/com/onenth/OneNth/domain/member/service/EmailVerificationService/EmailVerificationService.java
+++ b/src/main/java/com/onenth/OneNth/domain/member/service/EmailVerificationService/EmailVerificationService.java
@@ -26,8 +26,8 @@ public class EmailVerificationService {
             throw new RuntimeException("올바르지 않은 이메일 형식입니다.");
         }
 
+        // 이메일 중복 검증 (회원가입 DB와 연결 필요)
         if (memberRepository.existsByEmail(email)) {
-            // 이메일 중복 검증 (회원가입 DB와 연결 필요)
             throw new RuntimeException("이미 가입된 이메일입니다.");
         }
 

--- a/src/main/java/com/onenth/OneNth/global/configuration/WebConfig.java
+++ b/src/main/java/com/onenth/OneNth/global/configuration/WebConfig.java
@@ -1,7 +1,6 @@
 package com.onenth.OneNth.global.configuration;
 
 import com.onenth.OneNth.global.auth.resolver.AuthUserArgumentResolver;
-import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;

--- a/src/main/java/com/onenth/OneNth/global/configuration/security/SecurityConfig.java
+++ b/src/main/java/com/onenth/OneNth/global/configuration/security/SecurityConfig.java
@@ -33,6 +33,9 @@ public class SecurityConfig {
                                         "/api/members/login",
                                         "/api/email-auth/request-code",
                                         "/api/email-auth/verify-code",
+                                        "/api/auth/kakao/login",
+                                        "/api/auth/kakao/signup",
+                                        "/api/auth/kakao/callback",
                                         "/swagger-ui/**",
                                         "/v3/api-docs/**").permitAll()
                                 .anyRequest().authenticated()

--- a/src/main/java/com/onenth/OneNth/global/configuration/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/onenth/OneNth/global/configuration/security/jwt/JwtTokenProvider.java
@@ -42,8 +42,7 @@ public class JwtTokenProvider {
                 .compact();
     }
 
-    // 해당 JWT 토큰이 유효한지 검증해요. 파싱이 된다면 유효한 토큰이고,
-    // 토큰이 만료되었거나 (앞서 저희가 걸었던 4시간 제한을 넘어갔다거나) 혹은 위조, 형식 오류가 생기면 예외가 발생하여 false를 반환
+    // 토큰이 만료되었거나 혹은 위조, 형식 오류가 생기면 예외가 발생하여 false를 반환
     public boolean validateToken(String token) {
         try {
             Jwts.parserBuilder()
@@ -79,8 +78,6 @@ public class JwtTokenProvider {
         return null;
     }
 
-    // resolveToken 으로 JWT Access Token 을 꺼냄 validateToken 으로 토큰의 유효성 검증
-    // 토큰이 유효하면 getAuthentication() 을 호출해서 이메일 등 사용자 정보를 꺼내고
     // Spring Security 의 Authentication 객체로 변환
     public Authentication extractAuthentication(HttpServletRequest request){
         String accessToken = resolveToken(request);

--- a/src/main/java/com/onenth/OneNth/global/util/SecurityUtil.java
+++ b/src/main/java/com/onenth/OneNth/global/util/SecurityUtil.java
@@ -1,0 +1,27 @@
+package com.onenth.OneNth.global.util;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
+
+/**
+ * controller 외 전역에서 jwt 토큰에 정보를 사용할 수 있는 utility 클래스
+ */
+public class SecurityUtil {
+
+    public static Long getCurrentUserId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication == null || !authentication.isAuthenticated()) {
+            throw new RuntimeException("로그인 되지 않았습니다.");
+        }
+
+        Object principal = authentication.getPrincipal();
+
+        if (principal instanceof User user) {
+            return Long.valueOf(user.getUsername());
+        }
+
+        throw new RuntimeException("잘못된 사용자 정보입니다.");
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -48,7 +48,6 @@ spring:
             token-uri: https://kauth.kakao.com/oauth/token
             user-info-uri: https://kapi.kakao.com/v2/user/me
             user-name-attribute: id  # 카카오에서 식별자로 사용하는 필드
-
 jwt:
   token:
     secretKey: ${JWT_TOKEN_SECRET_KEY}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,9 +29,32 @@ spring:
             enable: true
   jackson:
     time-zone: Asia/Seoul
+  security:
+    oauth2:
+      client:
+        registration:
+          kakao:
+            client-id: ${KAKAO_CLIENT_ID}
+            client-secret: ${KAKAO_CLIENT_SECRET}
+            client-name: Kakao
+            authorization-grant-type: authorization_code
+            redirect-uri: "http://localhost:8080/api/auth/kakao/callback"
+            scope:
+              - profile_nickname
+              - account_email
+        provider:
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id  # 카카오에서 식별자로 사용하는 필드
+
 jwt:
   token:
     secretKey: ${JWT_TOKEN_SECRET_KEY}
     expiration:
       access: 14400000 # 4시간
       refresh: 1209600000 # 2주 (예시)
+kakao:
+  client_id: ${KAKAO_CLIENT_ID}
+  redirect_uri: http://localhost:8080/api/auth/kakao/callback


### PR DESCRIPTION
## **📌 작업 내용**

### **작업 API 스웨거 명세**
<img width="929" height="216" alt="카카오로그인회원가입스웨거" src="https://github.com/user-attachments/assets/6db17991-706e-4160-b93b-1cbb1917bed6" />

> ### 1. 카카오 소셜 로그인 구현
> 
> - Kakao Developer 에 앱정보를 등록했습니다.
> - 프론트가 전달해주는 카카오 인가코드로 사용자 정보를 가져오고 가입여부를 식별하는 로직을 구현하였습니다.
> - 만약 기존 가입 이력이 있다면 accessToken을 발급해 로그인 처리를 합니다. 가입 이력이 없다면(응답의 isNew가 True) 회원가입 로직으로 분기됩니다.

> ### 2. 카카오 소셜 회원가입 구현
> 
> - 기존 가입 이력이 없는 소셜 로그인 사용자의 정보를 저장합니다.
> - 카카오에서 받은 이메일, 소셜 ID, 이름 외에 **닉네임, 지역명, 마케팅 수신 동의 여부**를 프론트에서 받습니다.
> - 만약 일반 회원가입이 완료된 이메일이라면 예외처리 합니다.
> - 소셜 회원 정보가 등록됐다면 accessToken을 발급해 로그인 처리합니다.

```
📢

/**
  * 카카오 로그인 테스트
  */
https://kauth.kakao.com/oauth/authorize?response_type=code
&client_id={KAKAO_CLIENT_ID 값}
&redirect_uri=http://localhost:8080/api/auth/kakao/callback

1. 해당 uri를 브라우저 창으로 엽니다.
2. 카카오 아이디 비밀번호를 입력합니다. 
3. redirect uri로 넘어가게 되는데 리다이렉트 받을 화면이 없어서 직접 개발자 도구의 payload 에서 인가 코드를 복사합니다.
4. Swagger 카카오 로그인 api에 인가코드를 넣어 테스트 합니다.
```
❗카카오 로그인을 위한 application.yml 환경변수 설정은 노션의 환경변수 페이지를 참고해주세요.

## **✨ 참고 사항**

>카카오 소셜 로그인은 회원 등록 여부에 따라서 분기가 나뉘기 때문에 프론트와의 연결 시 코드 수정사항이 생길수 있습니다.
>

## **🧩 연관 이슈**

> close #6
>

<br>