### PR TITLE
[Feat] 닉네임/비밀번호/프로필 이미지 변경 API, 내 프로필 조회 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 
 	// Swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'

--- a/src/main/generated/com/onenth/OneNth/domain/member/entity/QMember.java
+++ b/src/main/generated/com/onenth/OneNth/domain/member/entity/QMember.java
@@ -51,6 +51,8 @@ public class QMember extends EntityPathBase<Member> {
 
     public final ListPath<com.onenth.OneNth.domain.post.entity.Post, com.onenth.OneNth.domain.post.entity.QPost> posts = this.<com.onenth.OneNth.domain.post.entity.Post, com.onenth.OneNth.domain.post.entity.QPost>createList("posts", com.onenth.OneNth.domain.post.entity.Post.class, com.onenth.OneNth.domain.post.entity.QPost.class, PathInits.DIRECT2);
 
+    public final StringPath profileImageUrl = createString("profileImageUrl");
+
     public final ListPath<com.onenth.OneNth.domain.product.entity.PurchaseItem, com.onenth.OneNth.domain.product.entity.QPurchaseItem> purchaseItems = this.<com.onenth.OneNth.domain.product.entity.PurchaseItem, com.onenth.OneNth.domain.product.entity.QPurchaseItem>createList("purchaseItems", com.onenth.OneNth.domain.product.entity.PurchaseItem.class, com.onenth.OneNth.domain.product.entity.QPurchaseItem.class, PathInits.DIRECT2);
 
     public final ListPath<com.onenth.OneNth.domain.product.entity.review.PurchaseReview, com.onenth.OneNth.domain.product.entity.review.QPurchaseReview> purchaseReviews = this.<com.onenth.OneNth.domain.product.entity.review.PurchaseReview, com.onenth.OneNth.domain.product.entity.review.QPurchaseReview>createList("purchaseReviews", com.onenth.OneNth.domain.product.entity.review.PurchaseReview.class, com.onenth.OneNth.domain.product.entity.review.QPurchaseReview.class, PathInits.DIRECT2);

--- a/src/main/generated/com/onenth/OneNth/domain/member/entity/QMember.java
+++ b/src/main/generated/com/onenth/OneNth/domain/member/entity/QMember.java
@@ -49,6 +49,8 @@ public class QMember extends EntityPathBase<Member> {
 
     public final ListPath<com.onenth.OneNth.domain.post.entity.Post, com.onenth.OneNth.domain.post.entity.QPost> posts = this.<com.onenth.OneNth.domain.post.entity.Post, com.onenth.OneNth.domain.post.entity.QPost>createList("posts", com.onenth.OneNth.domain.post.entity.Post.class, com.onenth.OneNth.domain.post.entity.QPost.class, PathInits.DIRECT2);
 
+    public final StringPath profileImageUrl = createString("profileImageUrl");
+
     public final ListPath<com.onenth.OneNth.domain.product.entity.PurchaseItem, com.onenth.OneNth.domain.product.entity.QPurchaseItem> purchaseItems = this.<com.onenth.OneNth.domain.product.entity.PurchaseItem, com.onenth.OneNth.domain.product.entity.QPurchaseItem>createList("purchaseItems", com.onenth.OneNth.domain.product.entity.PurchaseItem.class, com.onenth.OneNth.domain.product.entity.QPurchaseItem.class, PathInits.DIRECT2);
 
     public final ListPath<com.onenth.OneNth.domain.product.entity.review.PurchaseReview, com.onenth.OneNth.domain.product.entity.review.QPurchaseReview> purchaseReviews = this.<com.onenth.OneNth.domain.product.entity.review.PurchaseReview, com.onenth.OneNth.domain.product.entity.review.QPurchaseReview>createList("purchaseReviews", com.onenth.OneNth.domain.product.entity.review.PurchaseReview.class, com.onenth.OneNth.domain.product.entity.review.QPurchaseReview.class, PathInits.DIRECT2);

--- a/src/main/java/com/onenth/OneNth/domain/member/entity/Member.java
+++ b/src/main/java/com/onenth/OneNth/domain/member/entity/Member.java
@@ -53,6 +53,12 @@ public class Member extends BaseEntity {
     @Column(nullable=false)
     private boolean marketingAgree = false;
 
+    private String profileImageUrl;
+
+    public void updateProfileImage(String profileImageUrl) {
+        this.profileImageUrl = profileImageUrl;
+    }
+
     //비밀번호 salt 암호화 메서드
     public void encodePassword(String password) {
         this.password = password;

--- a/src/main/java/com/onenth/OneNth/domain/member/entity/Member.java
+++ b/src/main/java/com/onenth/OneNth/domain/member/entity/Member.java
@@ -59,6 +59,10 @@ public class Member extends BaseEntity {
         this.profileImageUrl = profileImageUrl;
     }
 
+    public void updateNickname(String nickname) {
+        this.nickname = nickname;
+    }
+
     //비밀번호 salt 암호화 메서드
     public void encodePassword(String password) {
         this.password = password;

--- a/src/main/java/com/onenth/OneNth/domain/member/settings/controller/UserSettingsController.java
+++ b/src/main/java/com/onenth/OneNth/domain/member/settings/controller/UserSettingsController.java
@@ -41,7 +41,7 @@ public class UserSettingsController {
     @PostMapping("/regions")
     public ApiResponse<UserSettingsResponseDTO.AddMyRegionResponseDTO> addMyRegion(
             @Parameter(hidden=true) @AuthUser Long userId,
-            @Valid @RequestBody UserSettingsRequestDTO.AddMyRegionRequestDTO request
+             @RequestBody UserSettingsRequestDTO.AddMyRegionRequestDTO request
     ) {
         return ApiResponse.onSuccess(userSettingsCommandService.addMyRegion(userId, request));
     }

--- a/src/main/java/com/onenth/OneNth/domain/member/settings/controller/UserSettingsController.java
+++ b/src/main/java/com/onenth/OneNth/domain/member/settings/controller/UserSettingsController.java
@@ -41,7 +41,7 @@ public class UserSettingsController {
     @PostMapping("/regions")
     public ApiResponse<UserSettingsResponseDTO.AddMyRegionResponseDTO> addMyRegion(
             @Parameter(hidden=true) @AuthUser Long userId,
-             @RequestBody UserSettingsRequestDTO.AddMyRegionRequestDTO request
+            @Valid @RequestBody UserSettingsRequestDTO.AddMyRegionRequestDTO request
     ) {
         return ApiResponse.onSuccess(userSettingsCommandService.addMyRegion(userId, request));
     }

--- a/src/main/java/com/onenth/OneNth/domain/member/settings/profile/controller/ProfileController.java
+++ b/src/main/java/com/onenth/OneNth/domain/member/settings/profile/controller/ProfileController.java
@@ -61,4 +61,21 @@ public class ProfileController {
     ) {
         return ApiResponse.onSuccess(profileCommandService.updateNickname(userId, request));
     }
+
+    @Operation(
+            summary =  "사용자 비밀번호 변경 API",
+            description = "사용자 설정 중 비밀번호를 변경하는 API입니다. 응답으로 아무것도 반환하지 않습니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 사용자 닉네임 변경 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "MEMBER001", description = "존재하지 않는 사용자입니다.", content = @Content(schema = @Schema(implementation = ErrorReasonDTO.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON500", description = "서버 에러, 관리자에게 문의 바랍니다", content = @Content(schema = @Schema(implementation = ErrorReasonDTO.class))),
+    })
+    @PatchMapping("/password")
+    public ApiResponse<Void> updatePassword(
+            @Parameter(hidden=true) @AuthUser Long userId,
+            @Valid @RequestBody ProfileRequestDTO.UpdatePasswordRequestDTO request
+    ) {
+        return ApiResponse.onSuccess(profileCommandService.updatePassword(userId, request));
+    }
 }

--- a/src/main/java/com/onenth/OneNth/domain/member/settings/profile/controller/ProfileController.java
+++ b/src/main/java/com/onenth/OneNth/domain/member/settings/profile/controller/ProfileController.java
@@ -1,0 +1,45 @@
+package com.onenth.OneNth.domain.member.settings.profile.controller;
+
+import com.onenth.OneNth.domain.member.settings.alert.generalAlert.dto.GeneralAlertResponseDTO;
+import com.onenth.OneNth.domain.member.settings.profile.dto.ProfileResponseDTO;
+import com.onenth.OneNth.domain.member.settings.profile.service.ProfileCommandService;
+import com.onenth.OneNth.global.apiPayload.ApiResponse;
+import com.onenth.OneNth.global.apiPayload.code.ErrorReasonDTO;
+import com.onenth.OneNth.global.auth.annotation.AuthUser;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+@Tag(name = "사용자 설정 - 계정 설정 관련 API", description = "프로필 이미지, 닉네임, 비밀번호 변경, 내 프로필 조회 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/user-settings/profile")
+public class ProfileController {
+
+    private final ProfileCommandService profileCommandService;
+
+    @Operation(
+            summary =  "사용자 프로필 이미지 변경 API",
+            description = "사용자 설정 중 프로필 이미지를 변경하는 API입니다. 응답으로 바뀐 프로필 이미지 url을 반환합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 알람 설정 전체 조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "MEMBER001", description = "존재하지 않는 사용자입니다.", content = @Content(schema = @Schema(implementation = ErrorReasonDTO.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "PROFILE001", description = "프로필 이미지가 비어 있거나 존재하지 않습니다.", content = @Content(schema = @Schema(implementation = ErrorReasonDTO.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON500", description = "서버 에러, 관리자에게 문의 바랍니다", content = @Content(schema = @Schema(implementation = ErrorReasonDTO.class))),
+    })
+    @PatchMapping(value = "/image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ApiResponse<ProfileResponseDTO.UpdateProfileImageResponseDTO> updateProfileImage(
+            @Parameter(hidden=true) @AuthUser Long userId,
+            @RequestPart("image") MultipartFile image
+    ) {
+        return ApiResponse.onSuccess(profileCommandService.updateProfileImage(userId, image));
+    }
+}

--- a/src/main/java/com/onenth/OneNth/domain/member/settings/profile/controller/ProfileController.java
+++ b/src/main/java/com/onenth/OneNth/domain/member/settings/profile/controller/ProfileController.java
@@ -4,6 +4,7 @@ import com.onenth.OneNth.domain.member.settings.alert.generalAlert.dto.GeneralAl
 import com.onenth.OneNth.domain.member.settings.profile.dto.ProfileRequestDTO;
 import com.onenth.OneNth.domain.member.settings.profile.dto.ProfileResponseDTO;
 import com.onenth.OneNth.domain.member.settings.profile.service.ProfileCommandService;
+import com.onenth.OneNth.domain.member.settings.profile.service.ProfileQueryService;
 import com.onenth.OneNth.global.apiPayload.ApiResponse;
 import com.onenth.OneNth.global.apiPayload.code.ErrorReasonDTO;
 import com.onenth.OneNth.global.auth.annotation.AuthUser;
@@ -26,6 +27,7 @@ import org.springframework.web.multipart.MultipartFile;
 public class ProfileController {
 
     private final ProfileCommandService profileCommandService;
+    private final ProfileQueryService profileQueryService;
 
     @Operation(
             summary =  "사용자 프로필 이미지 변경 API",
@@ -77,5 +79,21 @@ public class ProfileController {
             @Valid @RequestBody ProfileRequestDTO.UpdatePasswordRequestDTO request
     ) {
         return ApiResponse.onSuccess(profileCommandService.updatePassword(userId, request));
+    }
+
+    @Operation(
+            summary =  "사용자 내 프로필 조회 API",
+            description = "사용자 설정 중 내 프로필 조회 API입니다. 응답으로 프로필 사진, 닉네임을 반환합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 사용자 닉네임 변경 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "MEMBER001", description = "존재하지 않는 사용자입니다.", content = @Content(schema = @Schema(implementation = ErrorReasonDTO.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON500", description = "서버 에러, 관리자에게 문의 바랍니다", content = @Content(schema = @Schema(implementation = ErrorReasonDTO.class))),
+    })
+    @GetMapping("")
+    public ApiResponse<ProfileResponseDTO.GetMyProfileResponseDTO> getMyProfile(
+            @Parameter(hidden=true) @AuthUser Long userId
+    ) {
+        return ApiResponse.onSuccess(profileQueryService.getMyProfile(userId));
     }
 }

--- a/src/main/java/com/onenth/OneNth/domain/member/settings/profile/controller/ProfileController.java
+++ b/src/main/java/com/onenth/OneNth/domain/member/settings/profile/controller/ProfileController.java
@@ -1,6 +1,7 @@
 package com.onenth.OneNth.domain.member.settings.profile.controller;
 
 import com.onenth.OneNth.domain.member.settings.alert.generalAlert.dto.GeneralAlertResponseDTO;
+import com.onenth.OneNth.domain.member.settings.profile.dto.ProfileRequestDTO;
 import com.onenth.OneNth.domain.member.settings.profile.dto.ProfileResponseDTO;
 import com.onenth.OneNth.domain.member.settings.profile.service.ProfileCommandService;
 import com.onenth.OneNth.global.apiPayload.ApiResponse;
@@ -12,6 +13,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
@@ -30,7 +32,7 @@ public class ProfileController {
             description = "사용자 설정 중 프로필 이미지를 변경하는 API입니다. 응답으로 바뀐 프로필 이미지 url을 반환합니다."
     )
     @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 알람 설정 전체 조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 사용자 프로필 이미지 변경 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "MEMBER001", description = "존재하지 않는 사용자입니다.", content = @Content(schema = @Schema(implementation = ErrorReasonDTO.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "PROFILE001", description = "프로필 이미지가 비어 있거나 존재하지 않습니다.", content = @Content(schema = @Schema(implementation = ErrorReasonDTO.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON500", description = "서버 에러, 관리자에게 문의 바랍니다", content = @Content(schema = @Schema(implementation = ErrorReasonDTO.class))),
@@ -41,5 +43,22 @@ public class ProfileController {
             @RequestPart("image") MultipartFile image
     ) {
         return ApiResponse.onSuccess(profileCommandService.updateProfileImage(userId, image));
+    }
+
+    @Operation(
+            summary =  "사용자 닉네임 변경 API",
+            description = "사용자 설정 중 닉네임을 변경하는 API입니다. 응답으로 바뀐 닉네임을 반환합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 사용자 닉네임 변경 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "MEMBER001", description = "존재하지 않는 사용자입니다.", content = @Content(schema = @Schema(implementation = ErrorReasonDTO.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON500", description = "서버 에러, 관리자에게 문의 바랍니다", content = @Content(schema = @Schema(implementation = ErrorReasonDTO.class))),
+    })
+    @PatchMapping("/nickname")
+    public ApiResponse<ProfileResponseDTO.UpdateNicknameResponseDTO> updateNickname(
+            @Parameter(hidden=true) @AuthUser Long userId,
+            @Valid @RequestBody ProfileRequestDTO.UpdateNicknameRequestDTO request
+    ) {
+        return ApiResponse.onSuccess(profileCommandService.updateNickname(userId, request));
     }
 }

--- a/src/main/java/com/onenth/OneNth/domain/member/settings/profile/converter/ProfileConverter.java
+++ b/src/main/java/com/onenth/OneNth/domain/member/settings/profile/converter/ProfileConverter.java
@@ -1,0 +1,12 @@
+package com.onenth.OneNth.domain.member.settings.profile.converter;
+
+import com.onenth.OneNth.domain.member.settings.profile.dto.ProfileResponseDTO;
+import org.springframework.context.annotation.Profile;
+
+public class ProfileConverter {
+
+    public static ProfileResponseDTO.UpdateProfileImageResponseDTO toUpdateProfileImageResponseDTO(String imageUrl) {
+        return ProfileResponseDTO.UpdateProfileImageResponseDTO.builder()
+                .profileImageUrl(imageUrl).build();
+    }
+}

--- a/src/main/java/com/onenth/OneNth/domain/member/settings/profile/converter/ProfileConverter.java
+++ b/src/main/java/com/onenth/OneNth/domain/member/settings/profile/converter/ProfileConverter.java
@@ -16,4 +16,11 @@ public class ProfileConverter {
                 .nickname(member.getNickname())
                 .build();
     }
+
+    public static ProfileResponseDTO.GetMyProfileResponseDTO toGetMyProfileResponseDTO(Member member) {
+        return ProfileResponseDTO.GetMyProfileResponseDTO.builder()
+                .profileImageUrl(member.getProfileImageUrl())
+                .nickname(member.getNickname())
+                .build();
+    }
 }

--- a/src/main/java/com/onenth/OneNth/domain/member/settings/profile/converter/ProfileConverter.java
+++ b/src/main/java/com/onenth/OneNth/domain/member/settings/profile/converter/ProfileConverter.java
@@ -1,5 +1,6 @@
 package com.onenth.OneNth.domain.member.settings.profile.converter;
 
+import com.onenth.OneNth.domain.member.entity.Member;
 import com.onenth.OneNth.domain.member.settings.profile.dto.ProfileResponseDTO;
 import org.springframework.context.annotation.Profile;
 
@@ -8,5 +9,11 @@ public class ProfileConverter {
     public static ProfileResponseDTO.UpdateProfileImageResponseDTO toUpdateProfileImageResponseDTO(String imageUrl) {
         return ProfileResponseDTO.UpdateProfileImageResponseDTO.builder()
                 .profileImageUrl(imageUrl).build();
+    }
+
+    public static ProfileResponseDTO.UpdateNicknameResponseDTO toUpdateProfileImageResponseDTO(Member member) {
+        return ProfileResponseDTO.UpdateNicknameResponseDTO.builder()
+                .nickname(member.getNickname())
+                .build();
     }
 }

--- a/src/main/java/com/onenth/OneNth/domain/member/settings/profile/dto/ProfileRequestDTO.java
+++ b/src/main/java/com/onenth/OneNth/domain/member/settings/profile/dto/ProfileRequestDTO.java
@@ -1,0 +1,5 @@
+package com.onenth.OneNth.domain.member.settings.profile.dto;
+
+public class ProfileRequestDTO {
+
+}

--- a/src/main/java/com/onenth/OneNth/domain/member/settings/profile/dto/ProfileRequestDTO.java
+++ b/src/main/java/com/onenth/OneNth/domain/member/settings/profile/dto/ProfileRequestDTO.java
@@ -16,4 +16,12 @@ public class ProfileRequestDTO {
         private String nickname;
     }
 
+    @Getter
+    @NoArgsConstructor
+    public static class UpdatePasswordRequestDTO {
+        @Schema(description = "변경할 비밀번호", example = "abcd1234!")
+        @NotBlank(message = "변경할 비밀번호는 필수입니다.")
+        private String password;
+    }
+
 }

--- a/src/main/java/com/onenth/OneNth/domain/member/settings/profile/dto/ProfileRequestDTO.java
+++ b/src/main/java/com/onenth/OneNth/domain/member/settings/profile/dto/ProfileRequestDTO.java
@@ -1,5 +1,19 @@
 package com.onenth.OneNth.domain.member.settings.profile.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
 public class ProfileRequestDTO {
+
+    @Getter
+    @NoArgsConstructor
+    public static class UpdateNicknameRequestDTO {
+        @Schema(description = "변경할 닉네임", example = "갈래")
+        @NotBlank(message = "변경할 닉네임은 필수입니다.")
+        private String nickname;
+    }
 
 }

--- a/src/main/java/com/onenth/OneNth/domain/member/settings/profile/dto/ProfileResponseDTO.java
+++ b/src/main/java/com/onenth/OneNth/domain/member/settings/profile/dto/ProfileResponseDTO.java
@@ -17,4 +17,12 @@ public class ProfileResponseDTO {
         private String nickname;
     }
 
+    @Getter
+    @Builder
+    public static class GetMyProfileResponseDTO {
+        private String profileImageUrl;
+        private String nickname;
+    }
+
+
 }

--- a/src/main/java/com/onenth/OneNth/domain/member/settings/profile/dto/ProfileResponseDTO.java
+++ b/src/main/java/com/onenth/OneNth/domain/member/settings/profile/dto/ProfileResponseDTO.java
@@ -11,4 +11,10 @@ public class ProfileResponseDTO {
         private String profileImageUrl;
     }
 
+    @Getter
+    @Builder
+    public static class UpdateNicknameResponseDTO {
+        private String nickname;
+    }
+
 }

--- a/src/main/java/com/onenth/OneNth/domain/member/settings/profile/dto/ProfileResponseDTO.java
+++ b/src/main/java/com/onenth/OneNth/domain/member/settings/profile/dto/ProfileResponseDTO.java
@@ -1,0 +1,14 @@
+package com.onenth.OneNth.domain.member.settings.profile.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+public class ProfileResponseDTO {
+
+    @Getter
+    @Builder
+    public static class UpdateProfileImageResponseDTO {
+        private String profileImageUrl;
+    }
+
+}

--- a/src/main/java/com/onenth/OneNth/domain/member/settings/profile/service/ProfileCommandService.java
+++ b/src/main/java/com/onenth/OneNth/domain/member/settings/profile/service/ProfileCommandService.java
@@ -9,4 +9,6 @@ public interface ProfileCommandService {
     ProfileResponseDTO.UpdateProfileImageResponseDTO updateProfileImage(Long userId, MultipartFile image);
 
     ProfileResponseDTO.UpdateNicknameResponseDTO updateNickname(Long userId, ProfileRequestDTO.UpdateNicknameRequestDTO request);
+
+    Void updatePassword(Long userId, ProfileRequestDTO.UpdatePasswordRequestDTO request);
 }

--- a/src/main/java/com/onenth/OneNth/domain/member/settings/profile/service/ProfileCommandService.java
+++ b/src/main/java/com/onenth/OneNth/domain/member/settings/profile/service/ProfileCommandService.java
@@ -1,0 +1,9 @@
+package com.onenth.OneNth.domain.member.settings.profile.service;
+
+import com.onenth.OneNth.domain.member.settings.profile.dto.ProfileResponseDTO;
+import org.springframework.web.multipart.MultipartFile;
+
+public interface ProfileCommandService {
+
+    ProfileResponseDTO.UpdateProfileImageResponseDTO updateProfileImage(Long userId, MultipartFile image);
+}

--- a/src/main/java/com/onenth/OneNth/domain/member/settings/profile/service/ProfileCommandService.java
+++ b/src/main/java/com/onenth/OneNth/domain/member/settings/profile/service/ProfileCommandService.java
@@ -1,9 +1,12 @@
 package com.onenth.OneNth.domain.member.settings.profile.service;
 
+import com.onenth.OneNth.domain.member.settings.profile.dto.ProfileRequestDTO;
 import com.onenth.OneNth.domain.member.settings.profile.dto.ProfileResponseDTO;
 import org.springframework.web.multipart.MultipartFile;
 
 public interface ProfileCommandService {
 
     ProfileResponseDTO.UpdateProfileImageResponseDTO updateProfileImage(Long userId, MultipartFile image);
+
+    ProfileResponseDTO.UpdateNicknameResponseDTO updateNickname(Long userId, ProfileRequestDTO.UpdateNicknameRequestDTO request);
 }

--- a/src/main/java/com/onenth/OneNth/domain/member/settings/profile/service/ProfileCommandServiceImpl.java
+++ b/src/main/java/com/onenth/OneNth/domain/member/settings/profile/service/ProfileCommandServiceImpl.java
@@ -13,6 +13,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.hibernate.sql.Update;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -26,6 +27,7 @@ public class ProfileCommandServiceImpl implements ProfileCommandService {
 
     private final MemberRepository memberRepository;
     private final AmazonS3Manager amazonS3Manager;
+    private final PasswordEncoder passwordEncoder;
 
     @Override
     public ProfileResponseDTO.UpdateProfileImageResponseDTO updateProfileImage(Long userId, MultipartFile image) {
@@ -58,5 +60,15 @@ public class ProfileCommandServiceImpl implements ProfileCommandService {
         member.updateNickname(request.getNickname());
 
         return ProfileConverter.toUpdateProfileImageResponseDTO(member);
+    }
+
+    @Override
+    public Void updatePassword(Long userId, ProfileRequestDTO.UpdatePasswordRequestDTO request) {
+        Member member = memberRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+
+        member.encodePassword(passwordEncoder.encode(request.getPassword()));
+
+        return null;
     }
 }

--- a/src/main/java/com/onenth/OneNth/domain/member/settings/profile/service/ProfileCommandServiceImpl.java
+++ b/src/main/java/com/onenth/OneNth/domain/member/settings/profile/service/ProfileCommandServiceImpl.java
@@ -4,11 +4,15 @@ import com.onenth.OneNth.domain.member.entity.Member;
 import com.onenth.OneNth.domain.member.repository.memberRepository.MemberRepository;
 import com.onenth.OneNth.domain.member.settings.profile.controller.ProfileController;
 import com.onenth.OneNth.domain.member.settings.profile.converter.ProfileConverter;
+import com.onenth.OneNth.domain.member.settings.profile.dto.ProfileRequestDTO;
 import com.onenth.OneNth.domain.member.settings.profile.dto.ProfileResponseDTO;
 import com.onenth.OneNth.global.apiPayload.code.status.ErrorStatus;
 import com.onenth.OneNth.global.apiPayload.exception.GeneralException;
 import com.onenth.OneNth.global.aws.s3.AmazonS3Manager;
+import lombok.Builder;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import org.hibernate.sql.Update;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -44,5 +48,15 @@ public class ProfileCommandServiceImpl implements ProfileCommandService {
         member.updateProfileImage(imageUrl);
 
         return ProfileConverter.toUpdateProfileImageResponseDTO(imageUrl);
+    }
+
+    @Override
+    public ProfileResponseDTO.UpdateNicknameResponseDTO updateNickname(Long userId, ProfileRequestDTO.UpdateNicknameRequestDTO request) {
+        Member member = memberRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+
+        member.updateNickname(request.getNickname());
+
+        return ProfileConverter.toUpdateProfileImageResponseDTO(member);
     }
 }

--- a/src/main/java/com/onenth/OneNth/domain/member/settings/profile/service/ProfileCommandServiceImpl.java
+++ b/src/main/java/com/onenth/OneNth/domain/member/settings/profile/service/ProfileCommandServiceImpl.java
@@ -1,0 +1,48 @@
+package com.onenth.OneNth.domain.member.settings.profile.service;
+
+import com.onenth.OneNth.domain.member.entity.Member;
+import com.onenth.OneNth.domain.member.repository.memberRepository.MemberRepository;
+import com.onenth.OneNth.domain.member.settings.profile.controller.ProfileController;
+import com.onenth.OneNth.domain.member.settings.profile.converter.ProfileConverter;
+import com.onenth.OneNth.domain.member.settings.profile.dto.ProfileResponseDTO;
+import com.onenth.OneNth.global.apiPayload.code.status.ErrorStatus;
+import com.onenth.OneNth.global.apiPayload.exception.GeneralException;
+import com.onenth.OneNth.global.aws.s3.AmazonS3Manager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ProfileCommandServiceImpl implements ProfileCommandService {
+
+    private final MemberRepository memberRepository;
+    private final AmazonS3Manager amazonS3Manager;
+
+    @Override
+    public ProfileResponseDTO.UpdateProfileImageResponseDTO updateProfileImage(Long userId, MultipartFile image) {
+
+        if (image == null || image.isEmpty()) {
+            throw new GeneralException(ErrorStatus.INVALID_PROFILE_IMAGE);
+        }
+
+        Member member = memberRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+
+        if (member.getProfileImageUrl() != null) {
+            amazonS3Manager.deleteFile(member.getProfileImageUrl());
+        }
+
+        String uuid = UUID.randomUUID().toString();
+        String keyName = amazonS3Manager.generateProfileKeyName(uuid);
+        String imageUrl = amazonS3Manager.uploadFile(keyName, image);
+
+        member.updateProfileImage(imageUrl);
+
+        return ProfileConverter.toUpdateProfileImageResponseDTO(imageUrl);
+    }
+}

--- a/src/main/java/com/onenth/OneNth/domain/member/settings/profile/service/ProfileQueryService.java
+++ b/src/main/java/com/onenth/OneNth/domain/member/settings/profile/service/ProfileQueryService.java
@@ -1,0 +1,4 @@
+package com.onenth.OneNth.domain.member.settings.profile.service;
+
+public interface ProfileQueryService {
+}

--- a/src/main/java/com/onenth/OneNth/domain/member/settings/profile/service/ProfileQueryService.java
+++ b/src/main/java/com/onenth/OneNth/domain/member/settings/profile/service/ProfileQueryService.java
@@ -1,4 +1,8 @@
 package com.onenth.OneNth.domain.member.settings.profile.service;
 
+import com.onenth.OneNth.domain.member.settings.profile.dto.ProfileResponseDTO;
+
 public interface ProfileQueryService {
+
+    ProfileResponseDTO.GetMyProfileResponseDTO getMyProfile(Long userId);
 }

--- a/src/main/java/com/onenth/OneNth/domain/member/settings/profile/service/ProfileQueryServiceImpl.java
+++ b/src/main/java/com/onenth/OneNth/domain/member/settings/profile/service/ProfileQueryServiceImpl.java
@@ -1,0 +1,4 @@
+package com.onenth.OneNth.domain.member.settings.profile.service;
+
+public class ProfileQueryServiceImpl {
+}

--- a/src/main/java/com/onenth/OneNth/domain/member/settings/profile/service/ProfileQueryServiceImpl.java
+++ b/src/main/java/com/onenth/OneNth/domain/member/settings/profile/service/ProfileQueryServiceImpl.java
@@ -1,4 +1,26 @@
 package com.onenth.OneNth.domain.member.settings.profile.service;
 
-public class ProfileQueryServiceImpl {
+import com.onenth.OneNth.domain.member.entity.Member;
+import com.onenth.OneNth.domain.member.repository.memberRepository.MemberRepository;
+import com.onenth.OneNth.domain.member.settings.profile.converter.ProfileConverter;
+import com.onenth.OneNth.domain.member.settings.profile.dto.ProfileResponseDTO;
+import com.onenth.OneNth.global.apiPayload.code.status.ErrorStatus;
+import com.onenth.OneNth.global.apiPayload.exception.GeneralException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@RequiredArgsConstructor
+@Service
+public class ProfileQueryServiceImpl implements ProfileQueryService {
+
+    private final MemberRepository memberRepository;
+
+    public ProfileResponseDTO.GetMyProfileResponseDTO getMyProfile(Long userId) {
+        Member member = memberRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+
+        return ProfileConverter.toGetMyProfileResponseDTO(member);
+    }
 }

--- a/src/main/java/com/onenth/OneNth/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/onenth/OneNth/global/apiPayload/code/status/ErrorStatus.java
@@ -47,8 +47,12 @@ public enum ErrorStatus implements BaseErrorCode {
     //게시글 관련
     NOT_FOUND_POST(HttpStatus.NOT_FOUND, "POST_001", "게시글을 찾을 수 없습니다."),
 
+    // 알림 관련
     ALERT_SETTING_NOT_FOUND(HttpStatus.BAD_REQUEST, "ALERT_SETTING001", "해당 사용자의 알림 설정 정보가 존재하지 않습니다."),
     UNEXPECTED_ALERT_TYPE(HttpStatus.INTERNAL_SERVER_ERROR, "ALERT_002", "지원하지 않는 AlertType입니다."),
+
+    // 프로필 이미지 관련
+    INVALID_PROFILE_IMAGE(HttpStatus.BAD_REQUEST, "PROFILE001", "프로필 이미지가 비어 있거나 존재하지 않습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/onenth/OneNth/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/onenth/OneNth/global/apiPayload/code/status/ErrorStatus.java
@@ -12,6 +12,7 @@ public enum ErrorStatus implements BaseErrorCode {
 
     _INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "서버 에러, 관리자에게 문의 바랍니다."),
     _FORBIDDEN(HttpStatus.FORBIDDEN, "USER_4002", "금지된 요청입니다."),
+    _BAD_REQUEST(HttpStatus.BAD_REQUEST, "COMMON403", "입력값이 유효하지 않습니다."),
 
     // 회원 관련
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER001", "존재하지 않는 사용자입니다."),


### PR DESCRIPTION
## 📌 작업 내용

> 사용자 설정 중 계정 설정 관련 기능에 대한 API입니다. 닉네임 변경, 비밀번호 변경, 프로필 이미지 변경, 내 프로필 조회 기능 API입니다.

> 1. 프로필 이미지 변경 API
> - 이미지를 UUID 기반 파일명으로 업로드합니다.
> - 기존 프로필 이미지가 존재할 경우 S3에서 삭제 후 업로드된 파일로 교체됩니다.
> - 변경된 프로필 이미지 URL을 응답으로 반환합니다.
> - 프로필 이미지가 비어있는 경우 에러코드 `ErrorStatus.INVALID_PROFILE_IMAGE` 를 반환합니다.

> 2. 닉네임 변경 API
> - 변경된 닉네임을 응답으로 반환합니다.

> 3. 비밀번호 변경 API
> - 사용자 비밀번호를 암호화하여 저장합니다. 응답 데이터는 없습니다.

> 4. 내 프로필 조회 API
> - 피그마 기준으로 사용자 프로필 이미지 url과 사용자 닉네임을 반환합니다.

> 5. `Member` 엔티티 수정
> - 사용자 프로필 이미지 url을 저장하기 위한 `profileImageUrl` 필드를 추가했습니다.

> 6. `spring-boot-starter-validation` 의존성 추가
> - `@Valid`어노테이션이 정상적으로 작동하지 않는 문제를 해결하기 위해 `build.gradle`에 `spring-boot-starter-validation`의존성을 추가하였습니다.

> 7. `ErrorStatus._BAD_REQUEST` enum 추가
> - 기존 `GeneralHandler`의 `MethodArgumentNotValidException` 핸들러에서 사용한 `_BAD_REQUEST`를 처리해주지 못해 커스텀 예외 응답이 동작하지 않는 오류가 있어 해당 에러 코드를 추가하였습니다.

## ✨ 참고 사항

> - 이미지 업로드는 `@RequestPart`를 이용해 `multipart/form-data` 형식으로 받습니다.



## 🧩 연관 이슈

> close #37 


<br>