### PR TITLE
🐛 [Fix] 같이사요 & 함께나눠요 전반적인 로직 수정 

### DIFF
--- a/src/main/generated/com/onenth/OneNth/domain/product/entity/QPurchaseItem.java
+++ b/src/main/generated/com/onenth/OneNth/domain/product/entity/QPurchaseItem.java
@@ -35,6 +35,10 @@ public class QPurchaseItem extends EntityPathBase<PurchaseItem> {
 
     public final ListPath<ItemImage, QItemImage> itemImages = this.<ItemImage, QItemImage>createList("itemImages", ItemImage.class, QItemImage.class, PathInits.DIRECT2);
 
+    public final NumberPath<Double> latitude = createNumber("latitude", Double.class);
+
+    public final NumberPath<Double> longitude = createNumber("longitude", Double.class);
+
     public final com.onenth.OneNth.domain.member.entity.QMember member;
 
     public final StringPath name = createString("name");

--- a/src/main/generated/com/onenth/OneNth/domain/product/entity/QSharingItem.java
+++ b/src/main/generated/com/onenth/OneNth/domain/product/entity/QSharingItem.java
@@ -37,6 +37,10 @@ public class QSharingItem extends EntityPathBase<SharingItem> {
 
     public final ListPath<ItemImage, QItemImage> itemImages = this.<ItemImage, QItemImage>createList("itemImages", ItemImage.class, QItemImage.class, PathInits.DIRECT2);
 
+    public final NumberPath<Double> latitude = createNumber("latitude", Double.class);
+
+    public final NumberPath<Double> longitude = createNumber("longitude", Double.class);
+
     public final com.onenth.OneNth.domain.member.entity.QMember member;
 
     public final NumberPath<Integer> price = createNumber("price", Integer.class);
@@ -46,6 +50,8 @@ public class QSharingItem extends EntityPathBase<SharingItem> {
     public final NumberPath<Integer> quantity = createNumber("quantity", Integer.class);
 
     public final com.onenth.OneNth.domain.region.entity.QRegion region;
+
+    public final StringPath sharingLocation = createString("sharingLocation");
 
     public final ListPath<com.onenth.OneNth.domain.product.entity.review.SharingReview, com.onenth.OneNth.domain.product.entity.review.QSharingReview> sharingReviews = this.<com.onenth.OneNth.domain.product.entity.review.SharingReview, com.onenth.OneNth.domain.product.entity.review.QSharingReview>createList("sharingReviews", com.onenth.OneNth.domain.product.entity.review.SharingReview.class, com.onenth.OneNth.domain.product.entity.review.QSharingReview.class, PathInits.DIRECT2);
 

--- a/src/main/generated/com/onenth/OneNth/domain/region/entity/QRegion.java
+++ b/src/main/generated/com/onenth/OneNth/domain/region/entity/QRegion.java
@@ -26,6 +26,10 @@ public class QRegion extends EntityPathBase<Region> {
 
     public final NumberPath<Integer> id = createNumber("id", Integer.class);
 
+    public final NumberPath<Double> latitude = createNumber("latitude", Double.class);
+
+    public final NumberPath<Double> longitude = createNumber("longitude", Double.class);
+
     public final StringPath regionName = createString("regionName");
 
     //inherited

--- a/src/main/java/com/onenth/OneNth/domain/post/controller/PostRestController.java
+++ b/src/main/java/com/onenth/OneNth/domain/post/controller/PostRestController.java
@@ -1,6 +1,7 @@
 package com.onenth.OneNth.domain.post.controller;
 
 import com.onenth.OneNth.domain.member.entity.Member;
+import com.onenth.OneNth.domain.region.entity.Region;
 import com.onenth.OneNth.domain.post.dto.PostDetailResponseDTO;
 import com.onenth.OneNth.domain.post.dto.PostListResponseDTO;
 import com.onenth.OneNth.domain.post.dto.PostSaveRequestDTO;
@@ -100,12 +101,16 @@ public class PostRestController {
                 requestDto.setLongitude(result.getLongitude());
                 requestDto.setRegionName(result.getRegionName());
 
-                regionRepository.findByRegionNameContaining(result.getRegionName())
-                        .ifPresent(region -> requestDto.setRegionId(region.getId()));
+                // 기존 ifPresent → 다수 결과 예외 방지
+                List<Region> regions = regionRepository.findByRegionNameContaining(result.getRegionName());
+                if (!regions.isEmpty()) {
+                    requestDto.setRegionId(regions.get(0).getId()); // 가장 첫 번째 결과를 사용
+                }
 
             } catch (Exception e) {
                 throw new RuntimeException("좌표 조회 실패: " + e.getMessage(), e);
             }
+
         } else {
             requestDto.setLatitude(null);
             requestDto.setLongitude(null);

--- a/src/main/java/com/onenth/OneNth/domain/post/service/PostCommandServiceImpl.java
+++ b/src/main/java/com/onenth/OneNth/domain/post/service/PostCommandServiceImpl.java
@@ -97,8 +97,11 @@ public class PostCommandServiceImpl implements PostCommandService {
                     requestDto.setLongitude(result.getLongitude());
                     requestDto.setRegionName(result.getRegionName());
 
-                    regionRepository.findByRegionNameContaining(result.getRegionName())
-                            .ifPresent(region -> requestDto.setRegionId(region.getId()));
+                    // 기존 ifPresent → 예외 가능성 있음
+                    List<Region> matchedRegions = regionRepository.findByRegionNameContaining(result.getRegionName());
+                    if (!matchedRegions.isEmpty()) {
+                        requestDto.setRegionId(matchedRegions.get(0).getId());
+                    }
                 }
             }
         }

--- a/src/main/java/com/onenth/OneNth/domain/product/controller/PurchaseItemController.java
+++ b/src/main/java/com/onenth/OneNth/domain/product/controller/PurchaseItemController.java
@@ -95,7 +95,7 @@ public class PurchaseItemController {
             """
     )
   
-    @GetMapping("t /{groupPurchaseId}")
+    @GetMapping("/{groupPurchaseId}")
 
     public ApiResponse<PurchaseItemResponseDTO.GetPurchaseItemResponseDTO> getGroupPurchaseDetail(
             @PathVariable Long groupPurchaseId,

--- a/src/main/java/com/onenth/OneNth/domain/product/dto/PurchaseItemListDTO.java
+++ b/src/main/java/com/onenth/OneNth/domain/product/dto/PurchaseItemListDTO.java
@@ -16,6 +16,9 @@ public class PurchaseItemListDTO {
     private String thumbnailUrl;   // 썸네일 이미지 URL
     private boolean isBookmarked;  // 북마크(스크랩) 여부
 
+    private Double latitude;
+    private Double longitude;
+
     // 서비스에서 dto변환 로직이 길어지는 것을 방지하기위해 이쪽에 배치
     public static PurchaseItemListDTO fromEntity(PurchaseItem entity) {
         return PurchaseItemListDTO.builder()
@@ -28,6 +31,8 @@ public class PurchaseItemListDTO {
                                 ? entity.getItemImages().get(0).getUrl()
                                 : null
                 )
+                .latitude(entity.getLongitude())
+                .longitude(entity.getLongitude())
                 .isBookmarked(false)
                 .build();
     }

--- a/src/main/java/com/onenth/OneNth/domain/product/dto/PurchaseItemRequestDTO.java
+++ b/src/main/java/com/onenth/OneNth/domain/product/dto/PurchaseItemRequestDTO.java
@@ -19,7 +19,6 @@ public class PurchaseItemRequestDTO {
     private ItemCategory itemCategory;
     @NotBlank
     private String purchaseUrl;
-    @NotBlank
     private String purchaseLocation;
     private LocalDate expirationDate;
     @NotNull

--- a/src/main/java/com/onenth/OneNth/domain/product/dto/PurchaseItemRequestDTO.java
+++ b/src/main/java/com/onenth/OneNth/domain/product/dto/PurchaseItemRequestDTO.java
@@ -1,7 +1,10 @@
 package com.onenth.OneNth.domain.product.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.onenth.OneNth.domain.product.entity.enums.ItemCategory;
 import com.onenth.OneNth.domain.product.entity.enums.PurchaseMethod;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.validation.constraints.*;
 import lombok.Getter;
 import lombok.Setter;
@@ -14,6 +17,8 @@ public class PurchaseItemRequestDTO {
     @NotBlank
     private String name;
     @NotNull
+    @Enumerated(EnumType.STRING)
+    @JsonProperty("purchaseMethod")
     private PurchaseMethod purchaseMethod;
     @NotNull
     private ItemCategory itemCategory;

--- a/src/main/java/com/onenth/OneNth/domain/product/dto/PurchaseItemResponseDTO.java
+++ b/src/main/java/com/onenth/OneNth/domain/product/dto/PurchaseItemResponseDTO.java
@@ -36,5 +36,8 @@ public class PurchaseItemResponseDTO {
         private ItemCategory itemCategory;
         private PurchaseMethod purchaseMethod;
         private Integer originPrice;
+
+        private Double latitude;
+        private Double longitude;
     }
 }

--- a/src/main/java/com/onenth/OneNth/domain/product/dto/SharingItemListDTO.java
+++ b/src/main/java/com/onenth/OneNth/domain/product/dto/SharingItemListDTO.java
@@ -18,6 +18,9 @@ public class SharingItemListDTO {
     private String thumbnailUrl;    // 썸네일 이미지 URL
     private boolean isBookmarked;   // 북마크 여부 (스크랩 여부)
 
+    private Double latitude;
+    private Double longitude;
+
     public static SharingItemListDTO fromEntity(SharingItem entity) {
         return SharingItemListDTO.builder()
                 .id(entity.getId())
@@ -29,6 +32,8 @@ public class SharingItemListDTO {
                                 ? entity.getItemImages().get(0).getUrl()
                                 : null
                 )
+                .latitude(entity.getLongitude())
+                .longitude(entity.getLongitude())
                 .isBookmarked(false)
                 .build();
     }

--- a/src/main/java/com/onenth/OneNth/domain/product/dto/SharingItemRequestDTO.java
+++ b/src/main/java/com/onenth/OneNth/domain/product/dto/SharingItemRequestDTO.java
@@ -48,7 +48,6 @@ public class SharingItemRequestDTO {
     @NotEmpty
     private List<String> tags;
 
-    @NotBlank
-    private String sharingLocation; // 지도마커때문에 추가
+    private String sharingLocation;
 }
 

--- a/src/main/java/com/onenth/OneNth/domain/product/dto/SharingItemRequestDTO.java
+++ b/src/main/java/com/onenth/OneNth/domain/product/dto/SharingItemRequestDTO.java
@@ -47,5 +47,8 @@ public class SharingItemRequestDTO {
 
     @NotEmpty
     private List<String> tags;
+
+    @NotBlank
+    private String sharingLocation; // 지도마커때문에 추가
 }
 

--- a/src/main/java/com/onenth/OneNth/domain/product/dto/SharingItemRequestDTO.java
+++ b/src/main/java/com/onenth/OneNth/domain/product/dto/SharingItemRequestDTO.java
@@ -1,7 +1,10 @@
 package com.onenth.OneNth.domain.product.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.onenth.OneNth.domain.product.entity.enums.ItemCategory;
 import com.onenth.OneNth.domain.product.entity.enums.PurchaseMethod;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.validation.constraints.*;
 import lombok.*;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -37,6 +40,8 @@ public class SharingItemRequestDTO {
     private Boolean isAvailable;
 
     @NotNull
+    @Enumerated(EnumType.STRING)
+    @JsonProperty("purchaseMethod")
     private PurchaseMethod purchaseMethod;
 
     @NotNull

--- a/src/main/java/com/onenth/OneNth/domain/product/dto/SharingItemResponseDTO.java
+++ b/src/main/java/com/onenth/OneNth/domain/product/dto/SharingItemResponseDTO.java
@@ -38,6 +38,9 @@ public class SharingItemResponseDTO {
         private List<String> imageUrls;
         private List<String> tags;
         private String writerNickname;
+
+        private Double latitude;
+        private Double longitude;
     }
 }
 

--- a/src/main/java/com/onenth/OneNth/domain/product/entity/PurchaseItem.java
+++ b/src/main/java/com/onenth/OneNth/domain/product/entity/PurchaseItem.java
@@ -16,6 +16,7 @@ import java.util.List;
 
 @Entity
 @Getter
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder

--- a/src/main/java/com/onenth/OneNth/domain/product/entity/PurchaseItem.java
+++ b/src/main/java/com/onenth/OneNth/domain/product/entity/PurchaseItem.java
@@ -69,4 +69,10 @@ public class PurchaseItem extends BaseEntity {
             inverseJoinColumns = @JoinColumn(name = "tag_id")
     )
     private List<Tag> tags = new ArrayList<>();// +
+
+    @Column
+    private Double latitude;
+
+    @Column
+    private Double longitude;
 }

--- a/src/main/java/com/onenth/OneNth/domain/product/entity/PurchaseItem.java
+++ b/src/main/java/com/onenth/OneNth/domain/product/entity/PurchaseItem.java
@@ -36,7 +36,7 @@ public class PurchaseItem extends BaseEntity {
     @Column(nullable = false)
     private ItemCategory itemCategory;
 
-    @Column(length = 300, nullable = false)
+    @Column(length = 300, nullable = true)
     private String purchaseLocation;
 
     private LocalDate expirationDate;

--- a/src/main/java/com/onenth/OneNth/domain/product/entity/SharingItem.java
+++ b/src/main/java/com/onenth/OneNth/domain/product/entity/SharingItem.java
@@ -17,6 +17,7 @@ import java.util.List;
 
 @Entity
 @Getter
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder

--- a/src/main/java/com/onenth/OneNth/domain/product/entity/SharingItem.java
+++ b/src/main/java/com/onenth/OneNth/domain/product/entity/SharingItem.java
@@ -73,4 +73,15 @@ public class SharingItem extends BaseEntity {
             inverseJoinColumns = @JoinColumn(name = "tag_id")
     )
     private List<Tag> tags = new ArrayList<>();
+
+    // +
+
+    @Column(length = 300, nullable = false)
+    private String sharingLocation;
+
+    @Column
+    private Double latitude;
+
+    @Column
+    private Double longitude;
 }

--- a/src/main/java/com/onenth/OneNth/domain/product/entity/SharingItem.java
+++ b/src/main/java/com/onenth/OneNth/domain/product/entity/SharingItem.java
@@ -75,8 +75,7 @@ public class SharingItem extends BaseEntity {
     private List<Tag> tags = new ArrayList<>();
 
     // +
-
-    @Column(length = 300, nullable = false)
+    @Column(length = 300, nullable = true)
     private String sharingLocation;
 
     @Column

--- a/src/main/java/com/onenth/OneNth/domain/product/repository/itemRepository/purchase/PurchaseItemRepository.java
+++ b/src/main/java/com/onenth/OneNth/domain/product/repository/itemRepository/purchase/PurchaseItemRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface PurchaseItemRepository  extends JpaRepository<PurchaseItem, Long>, PurchaseItemRepositoryCustom {
     List<PurchaseItem> findByMember(Member member);
@@ -24,4 +25,11 @@ public interface PurchaseItemRepository  extends JpaRepository<PurchaseItem, Lon
     // 상품명(전체 조회)
     List<PurchaseItem> findByNameContainingIgnoreCase(String keyword);
 
+    @Query("""
+    SELECT p
+    FROM PurchaseItem p
+    JOIN FETCH p.region
+    WHERE p.id = :id
+    """)
+    Optional<PurchaseItem> findWithRegionById(@Param("id") Long id);
 }

--- a/src/main/java/com/onenth/OneNth/domain/product/repository/itemRepository/sharing/SharingItemRepository.java
+++ b/src/main/java/com/onenth/OneNth/domain/product/repository/itemRepository/sharing/SharingItemRepository.java
@@ -25,4 +25,13 @@ public interface SharingItemRepository extends JpaRepository<SharingItem, Long>,
 
     // 상품명(전체 조회)
     List<SharingItem> findByTitleContainingIgnoreCase(String keyword);
+
+    @Query("""
+    SELECT s
+    FROM SharingItem s
+    JOIN FETCH s.region
+    WHERE s.id = :id
+    """)
+    Optional<SharingItem> findWithRegionById(@Param("id") Long id);
+
 }

--- a/src/main/java/com/onenth/OneNth/domain/product/service/PurchaseItemService.java
+++ b/src/main/java/com/onenth/OneNth/domain/product/service/PurchaseItemService.java
@@ -215,7 +215,7 @@ public class PurchaseItemService {
         }
 
     private boolean isRegion(String keyword){
-        return regionRepository.findByRegionNameContaining(keyword).isPresent();
+        return !regionRepository.findByRegionNameContaining(keyword).isEmpty();
     }
 
     // 상품명 검색++++

--- a/src/main/java/com/onenth/OneNth/domain/product/service/PurchaseItemService.java
+++ b/src/main/java/com/onenth/OneNth/domain/product/service/PurchaseItemService.java
@@ -124,7 +124,7 @@ public class PurchaseItemService {
                 .build();
         purchaseItem.getTags().addAll(tagEntities);
 
-        // 2. ONLINE이면 대표지역 위도경도 설정
+        // ONLINE이면 대표지역 위도경도 설정
         if (dto.getPurchaseMethod().equals(PurchaseMethod.ONLINE)) {
             Region mainRegion = memberRegionRepository.findByMemberId(userId)
                     .stream()

--- a/src/main/java/com/onenth/OneNth/domain/product/service/PurchaseItemService.java
+++ b/src/main/java/com/onenth/OneNth/domain/product/service/PurchaseItemService.java
@@ -274,6 +274,8 @@ public class PurchaseItemService {
                 .itemCategory(item.getItemCategory())
                 .purchaseMethod(item.getPurchaseMethod())
                 .originPrice(item.getPrice())
+                .latitude(item.getLatitude())
+                .longitude(item.getLongitude())
                 .build();
     }
 

--- a/src/main/java/com/onenth/OneNth/domain/product/service/SharingItemService.java
+++ b/src/main/java/com/onenth/OneNth/domain/product/service/SharingItemService.java
@@ -17,6 +17,8 @@ import com.onenth.OneNth.domain.product.repository.itemRepository.TagRepository;
 import com.onenth.OneNth.domain.product.repository.itemRepository.sharing.SharingItemRepository;
 import com.onenth.OneNth.domain.region.entity.Region;
 import com.onenth.OneNth.domain.region.repository.RegionRepository;
+import com.onenth.OneNth.global.external.kakao.dto.GeoCodingResult;
+import com.onenth.OneNth.global.external.kakao.service.GeoCodingService;
 import lombok.RequiredArgsConstructor;
 import com.onenth.OneNth.domain.product.entity.Tag;
 import com.onenth.OneNth.domain.product.entity.enums.ItemType;
@@ -39,6 +41,7 @@ public class SharingItemService {
     private final MemberRegionRepository memberRegionRepository;
     private final TagRepository tagRepository;
     private final RegionRepository regionRepository;
+    private final GeoCodingService geoCodingService;
 
     private final AmazonS3 amazonS3;
 
@@ -102,6 +105,11 @@ public class SharingItemService {
             throw new IllegalArgumentException("이미지는 최대 3장까지 업로드할 수 있습니다.");
         }
 
+        GeoCodingResult geo = geoCodingService.getCoordinatesFromAddress(dto.getSharingLocation());
+        if (geo == null) {
+            throw new IllegalArgumentException("유효한 주소를 입력해주세요.");
+        }
+
         SharingItem sharingItem = SharingItem.builder()
                 .title(dto.getTitle())
                 .quantity(dto.getQuantity())
@@ -114,6 +122,9 @@ public class SharingItemService {
                 .region(region)
                 .status(Status.DEFAULT)
                 .tags(new ArrayList<>())
+//                .sharingLocation(dto.getSharingLocation())
+//                .latitude(geo.getLatitude()) // 위도 추가
+//                .longitude(geo.getLongitude()) // 경도 추가
                 .build();
         sharingItem.getTags().addAll(tagEntities); // +
         sharingItemRepository.save(sharingItem);

--- a/src/main/java/com/onenth/OneNth/domain/product/service/SharingItemService.java
+++ b/src/main/java/com/onenth/OneNth/domain/product/service/SharingItemService.java
@@ -285,6 +285,8 @@ public class SharingItemService {
                 .imageUrls(imageUrls)
                 .tags(tags)
                 .writerNickname(member.getNickname())
+                .latitude(item.getLatitude())
+                .longitude(item.getLongitude())
                 .build();
     }
 

--- a/src/main/java/com/onenth/OneNth/domain/product/service/SharingItemService.java
+++ b/src/main/java/com/onenth/OneNth/domain/product/service/SharingItemService.java
@@ -243,10 +243,9 @@ public class SharingItemService {
         }
     }
 
-    private boolean isRegion(String keyword) {
-        return regionRepository.findByRegionNameContaining(keyword).isPresent();
+    private boolean isRegion(String keyword){
+        return !regionRepository.findByRegionNameContaining(keyword).isEmpty();
     }
-
 
     // 단일 상품 리스트 조회
     @Transactional(readOnly = true)

--- a/src/main/java/com/onenth/OneNth/domain/region/entity/Region.java
+++ b/src/main/java/com/onenth/OneNth/domain/region/entity/Region.java
@@ -6,6 +6,7 @@ import lombok.*;
 
 @Entity
 @Getter
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder

--- a/src/main/java/com/onenth/OneNth/domain/region/entity/Region.java
+++ b/src/main/java/com/onenth/OneNth/domain/region/entity/Region.java
@@ -17,4 +17,11 @@ public class Region extends BaseEntity {
 
     @Column(nullable = false, unique = true)
     private String regionName;
+
+    // ONLINE일 경우
+    @Column
+    private Double latitude;
+
+    @Column
+    private Double longitude;
 }

--- a/src/main/java/com/onenth/OneNth/domain/region/repository/RegionRepository.java
+++ b/src/main/java/com/onenth/OneNth/domain/region/repository/RegionRepository.java
@@ -4,10 +4,11 @@ import com.onenth.OneNth.domain.region.entity.Region;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface RegionRepository extends JpaRepository<Region, Long> {
     Optional<Region> findByRegionName (String regionName);
-    Optional<Region> findByRegionNameContaining(String regionName);
+    List<Region> findByRegionNameContaining(String regionName);
 }


### PR DESCRIPTION
## 📌 작업 내용

> 같이사요 상품등록 온오프라인여부에따라 장소예외처리 v
	테스트 내용:
	온라인일때 주소입력하면 상품등록 안되게하기 v
	온라인일때 주소입력지우면 상품등록 되게 하기 v
	오프라인일때 주소입력지우면 상품등록 안되게 하기 v
	오프라인일때 주소입력하면 상품등록 되게하기 v
	같이사요 상품등록 지오로직 저장 v

함께나눠요 상품등록 온오프라인여부에따라 장소예외처리
함께나눠요 상품등록 지오로직 저장
	테스트 내용:
	온라인일때 주소입력하면 상품등록 안되게하기 v
	온라인일때 주소입력지우면 상품등록 되게 하기 v
	오프라인일때 주소입력지우면 상품등록 안되게 하기 v
	오프라인일때 주소입력하면 상품등록 되게하기 v
	같이사요 상품등록 지오로직 저장 v

단일 상품 조회시 위도경도 데이터값 반환필요(반환확인)
전체상품조회시 위도경도 데이터값 반환필요(반환확인)

상품등록시 온라인의 경우 대표 지역의 위도/경도로 자동 설정(반환확인)

같이사요

온라인 상품일 경우 등록 후 단일상품조회시 위도 경도 떠야함 v
오프라인 상품일 경우 위치 등록 후 단일 상품 조회 시 위도경도 떠야함.v

함께나눠요

온라인 상품일 경우 등록 후 단일상품조회시 위도 경도 떠야함 v
오프라인 상품일 경우 위치 등록 후 단일 상품 조회 시 위도경도 떠야함.v

## ✨ 참고 사항

> 엔티티 purchaselocation의 에너테이션 변경

## 🧩 연관 이슈

> close #68 


<br>