### PR TITLE
✨[Feat] 게시글 댓글 등록, 댓글 목록 조회, 삭제 기능 API 구현

### DIFF
--- a/src/main/java/com/onenth/OneNth/domain/post/controller/PostCommentRestController.java
+++ b/src/main/java/com/onenth/OneNth/domain/post/controller/PostCommentRestController.java
@@ -1,0 +1,78 @@
+package com.onenth.OneNth.domain.post.controller;
+
+import com.onenth.OneNth.domain.post.converter.PostCommentConverter;
+import com.onenth.OneNth.domain.post.dto.PostCommentResponseDTO;
+import com.onenth.OneNth.domain.post.dto.PostCommentSaveRequestDTO;
+import com.onenth.OneNth.domain.post.entity.PostComment;
+import com.onenth.OneNth.domain.post.service.PostCommentCommandService;
+import com.onenth.OneNth.domain.post.service.PostCommentQueryService;
+import com.onenth.OneNth.global.apiPayload.ApiResponse;
+import com.onenth.OneNth.global.apiPayload.code.status.SuccessStatus;
+import com.onenth.OneNth.global.auth.annotation.AuthUser;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "게시글 댓글 관련 API", description = "생활꿀팁/할인정보/우리동네맛집 게시글 댓글 API")
+@RestController
+@RequestMapping("/api/post/{postId}/comment")
+@RequiredArgsConstructor
+public class PostCommentRestController {
+
+    private final PostCommentCommandService postCommentCommandService;
+    private final PostCommentQueryService postCommentQueryService;
+
+    @Operation(
+            summary = "게시글 댓글 등록 API",
+            description = """
+    생활꿀팁/할인정보/우리동네맛집 게시글의 댓글을 등록하는 API입니다.
+    - 쿼리 파라미터 'postId'에 '게시글 Id'를 명시합니다.
+    - 댓글 내용(content)을 JSON 문자열로 포함해야 합니다.
+    """)
+    @PostMapping
+    public ApiResponse<PostCommentResponseDTO> createComment(
+            @PathVariable Long postId,
+            @AuthUser Long memberId,
+            @RequestBody PostCommentSaveRequestDTO requestDTO
+    ) {
+        Long commentId = postCommentCommandService.saveComment(postId, memberId, requestDTO);
+        PostComment comment = postCommentCommandService.findById(commentId); // 새로 저장된 댓글 조회
+
+        PostCommentResponseDTO responseDto = PostCommentConverter.toResponseDTO(comment);
+        return ApiResponse.of(SuccessStatus._OK, responseDto);
+    }
+
+    @Operation(summary = "게시글 댓글 삭제 API",
+            description = """
+    생활꿀팁/할인정보/우리동네맛집 게시글의 댓글을 삭제하는 API입니다.
+    - 쿼리 파라미터 'postId'와 'commentId'를 명시합니다.
+    - 본인이 작성한 게시글에 대해서만 삭제 권한이 있습니다.
+    """)
+    @DeleteMapping("/{commentId}")
+    public ApiResponse<Void> deleteComment(
+            @PathVariable Long postId,
+            @PathVariable Long commentId,
+            @AuthUser Long memberId
+    ) {
+        postCommentCommandService.deleteComment(commentId, memberId);
+        return ApiResponse.of(SuccessStatus._OK, null);
+    }
+
+
+    @Operation(summary = "게시글 댓글 목록 조회 API",
+            description = """
+    생활꿀팁/할인정보/우리동네맛집 게시글의 댓글 목록을 조회하는 API입니다.
+    - 쿼리 파라미터 'postId'를 명시합니다.
+    - 해당 게시글에 달린 댓글의 id, 내용, 작성자 닉네임, 작성자 id, 생성일자가 결과값으로 제공됩니다.
+    """)
+    @GetMapping("/list")
+    public ApiResponse<List<PostCommentResponseDTO>> getComments(
+            @PathVariable Long postId
+    ) {
+        List<PostCommentResponseDTO> comments = postCommentQueryService.getCommentsByPostId(postId);
+        return ApiResponse.of(SuccessStatus._OK, comments);
+    }
+}

--- a/src/main/java/com/onenth/OneNth/domain/post/converter/PostCommentConverter.java
+++ b/src/main/java/com/onenth/OneNth/domain/post/converter/PostCommentConverter.java
@@ -1,0 +1,28 @@
+package com.onenth.OneNth.domain.post.converter;
+
+import com.onenth.OneNth.domain.member.entity.Member;
+import com.onenth.OneNth.domain.post.dto.PostCommentResponseDTO;
+import com.onenth.OneNth.domain.post.dto.PostCommentSaveRequestDTO;
+import com.onenth.OneNth.domain.post.entity.Post;
+import com.onenth.OneNth.domain.post.entity.PostComment;
+
+public class PostCommentConverter {
+
+    public static PostComment toEntity(PostCommentSaveRequestDTO dto, Post post, Member member) {
+        return PostComment.builder()
+                .post(post)
+                .member(member)
+                .content(dto.getContent())
+                .build();
+    }
+
+    public static PostCommentResponseDTO toResponseDTO(PostComment entity) {
+        return PostCommentResponseDTO.builder()
+                .id(entity.getId())
+                .content(entity.getContent())
+                .nickname(entity.getMember().getNickname())
+                .memberId(entity.getMember().getId())
+                .createdAt(entity.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/onenth/OneNth/domain/post/dto/PostCommentResponseDTO.java
+++ b/src/main/java/com/onenth/OneNth/domain/post/dto/PostCommentResponseDTO.java
@@ -1,0 +1,30 @@
+package com.onenth.OneNth.domain.post.dto;
+
+import com.onenth.OneNth.domain.post.entity.PostComment;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class PostCommentResponseDTO {
+
+    private Long id;
+    private String content;
+    private String nickname;
+    private Long memberId;
+    private LocalDateTime createdAt;
+
+
+    public static PostCommentResponseDTO fromEntity(PostComment comment) {
+        return PostCommentResponseDTO.builder()
+                .id(comment.getId())
+                .content(comment.getContent())
+                .nickname(comment.getMember().getNickname())
+                .memberId(comment.getMember().getId())
+                .createdAt(comment.getCreatedAt())
+                .build();
+    }
+
+}

--- a/src/main/java/com/onenth/OneNth/domain/post/dto/PostCommentSaveRequestDTO.java
+++ b/src/main/java/com/onenth/OneNth/domain/post/dto/PostCommentSaveRequestDTO.java
@@ -1,0 +1,8 @@
+package com.onenth.OneNth.domain.post.dto;
+
+import lombok.Getter;
+
+@Getter
+public class PostCommentSaveRequestDTO {
+    private String content;
+}

--- a/src/main/java/com/onenth/OneNth/domain/post/entity/Post.java
+++ b/src/main/java/com/onenth/OneNth/domain/post/entity/Post.java
@@ -1,6 +1,7 @@
 package com.onenth.OneNth.domain.post.entity;
 
 import com.onenth.OneNth.domain.common.BaseEntity;
+import com.onenth.OneNth.domain.common.QBaseEntity;
 import com.onenth.OneNth.domain.post.entity.enums.PostType;
 import com.onenth.OneNth.domain.region.entity.Region;
 import com.onenth.OneNth.domain.member.entity.Member;

--- a/src/main/java/com/onenth/OneNth/domain/post/repository/commentRepository/CommentRepository.java
+++ b/src/main/java/com/onenth/OneNth/domain/post/repository/commentRepository/CommentRepository.java
@@ -4,8 +4,12 @@ import com.onenth.OneNth.domain.post.entity.Post;
 import com.onenth.OneNth.domain.post.entity.PostComment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface CommentRepository extends JpaRepository<PostComment, Long> {
 
     long countByPost(Post post);
+
+    List<PostComment> findByPostIdOrderByCreatedAtDesc(Long postId);
 
 }

--- a/src/main/java/com/onenth/OneNth/domain/post/service/PostCommentCommandService.java
+++ b/src/main/java/com/onenth/OneNth/domain/post/service/PostCommentCommandService.java
@@ -1,0 +1,10 @@
+package com.onenth.OneNth.domain.post.service;
+
+import com.onenth.OneNth.domain.post.dto.PostCommentSaveRequestDTO;
+import com.onenth.OneNth.domain.post.entity.PostComment;
+
+public interface PostCommentCommandService {
+    Long saveComment(Long postId, Long memberId, PostCommentSaveRequestDTO requestDto);
+    void deleteComment(Long commentId, Long memberId);
+    PostComment findById(Long commentId);
+}

--- a/src/main/java/com/onenth/OneNth/domain/post/service/PostCommentCommandServiceImpl.java
+++ b/src/main/java/com/onenth/OneNth/domain/post/service/PostCommentCommandServiceImpl.java
@@ -1,0 +1,59 @@
+package com.onenth.OneNth.domain.post.service;
+
+import com.onenth.OneNth.domain.member.entity.Member;
+import com.onenth.OneNth.domain.member.repository.memberRepository.MemberRepository;
+import com.onenth.OneNth.domain.post.dto.PostCommentSaveRequestDTO;
+import com.onenth.OneNth.domain.post.entity.Post;
+import com.onenth.OneNth.domain.post.entity.PostComment;
+import com.onenth.OneNth.domain.post.repository.PostRepository;
+import com.onenth.OneNth.domain.post.repository.commentRepository.CommentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PostCommentCommandServiceImpl implements PostCommentCommandService{
+
+    private final CommentRepository commentRepository;
+    private final PostRepository postRepository;
+    private final MemberRepository memberRepository;
+
+    @Override
+    @Transactional
+    public Long saveComment(Long postId, Long memberId, PostCommentSaveRequestDTO requestDto) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 게시글입니다."));
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
+
+        PostComment comment = PostComment.builder()
+                .post(post)
+                .member(member)
+                .content(requestDto.getContent())
+                .build();
+
+        commentRepository.saveAndFlush(comment);
+
+        return comment.getId();
+    }
+
+    @Override
+    @Transactional
+    public void deleteComment(Long commentId, Long memberId) {
+        PostComment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 댓글입니다."));
+
+        if (!comment.getMember().getId().equals(memberId)) {
+            throw new SecurityException("본인의 댓글만 삭제할 수 있습니다.");
+        }
+
+        commentRepository.delete(comment);
+    }
+
+    @Override
+    public PostComment findById(Long commentId) {
+        return commentRepository.findById(commentId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 댓글입니다."));
+    }
+}

--- a/src/main/java/com/onenth/OneNth/domain/post/service/PostCommentQueryService.java
+++ b/src/main/java/com/onenth/OneNth/domain/post/service/PostCommentQueryService.java
@@ -1,0 +1,9 @@
+package com.onenth.OneNth.domain.post.service;
+
+import com.onenth.OneNth.domain.post.dto.PostCommentResponseDTO;
+
+import java.util.List;
+
+public interface PostCommentQueryService {
+    List<PostCommentResponseDTO> getCommentsByPostId(Long postId);
+}

--- a/src/main/java/com/onenth/OneNth/domain/post/service/PostCommentQueryServiceImpl.java
+++ b/src/main/java/com/onenth/OneNth/domain/post/service/PostCommentQueryServiceImpl.java
@@ -1,0 +1,28 @@
+package com.onenth.OneNth.domain.post.service;
+
+import com.onenth.OneNth.domain.post.dto.PostCommentResponseDTO;
+import com.onenth.OneNth.domain.post.entity.PostComment;
+import com.onenth.OneNth.domain.post.repository.commentRepository.CommentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class PostCommentQueryServiceImpl implements PostCommentQueryService{
+
+    private final CommentRepository commentRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<PostCommentResponseDTO> getCommentsByPostId(Long postId) {
+        List<PostComment> comments = commentRepository.findByPostIdOrderByCreatedAtDesc(postId);
+
+        return comments.stream()
+                .map(PostCommentResponseDTO::fromEntity)
+                .toList();
+    }
+
+}


### PR DESCRIPTION
## 📌 작업 내용

### **작업 API 스웨거 명세**
<img width="1228" height="350" alt="image" src="https://github.com/user-attachments/assets/e498a80b-762e-4bb6-be3f-6b6c8579d9d4" />

> 

>###  **1. 게시글 댓글 등록 API 구현**
> - postId를 이용하여 게시글 댓글을 등록하는 API입니다. 
> - 쿼리 파라미터 'postId'에 '게시글 Id'를 명시합니다.
> - 댓글 내용(content)을 JSON 문자열로 포함해야 합니다.
 
> ### **2. 게시글 댓글 목록 조회 API 구현**
> - postId를 이용하여 게시글의 댓글 목록을 조회하는 API입니다. 
> - 쿼리 파라미터 'postId'를 명시합니다.
> - 해당 게시글에 달린 댓글의 id, 내용, 작성자 닉네임, 작성자 id, 생성일자가 결과값으로 제공됩니다.

> ### **3. 게시글 댓글 삭제 API 구현**
> - postId, commentId를 이용한 게시글 댓글 삭제 API입니다. 
> - 본인이 작성한 게시글에 대해서만 삭제 권한이 있습니다.

## ✨ 참고 사항

> PM님과 논의하에 대댓글 기능은 제외하기로 하였습니다.

## 🧩 연관 이슈

> close #78


<br>