### PR TITLE
✨[Feat] 게시글 공감, 스크랩 등록 삭제 기능 API 구현

### DIFF
--- a/src/main/java/com/onenth/OneNth/domain/member/dto/MemberResponseDTO.java
+++ b/src/main/java/com/onenth/OneNth/domain/member/dto/MemberResponseDTO.java
@@ -78,6 +78,14 @@ public class MemberResponseDTO {
         Boolean isSuccess;
     }
 
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class AddScrapOrLikeResponseDTO {
+        Boolean isSuccess;
+    }
+
 //    @Builder
 //    @Getter
 //    @NoArgsConstructor

--- a/src/main/java/com/onenth/OneNth/domain/member/service/memberService/MemberCommandService.java
+++ b/src/main/java/com/onenth/OneNth/domain/member/service/memberService/MemberCommandService.java
@@ -2,10 +2,6 @@ package com.onenth.OneNth.domain.member.service.memberService;
 
 import com.onenth.OneNth.domain.member.dto.MemberRequestDTO;
 import com.onenth.OneNth.domain.member.dto.MemberResponseDTO;
-import com.onenth.OneNth.domain.member.entity.Member;
-import com.onenth.OneNth.domain.member.repository.memberRepository.MemberRepository;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
 
 
 public interface MemberCommandService {

--- a/src/main/java/com/onenth/OneNth/domain/member/service/memberService/MemberCommandService.java
+++ b/src/main/java/com/onenth/OneNth/domain/member/service/memberService/MemberCommandService.java
@@ -19,8 +19,14 @@ public interface MemberCommandService {
     //비밀번호 재설정 로직 구현
     MemberResponseDTO.PasswordResetResultDTO resetPassword(MemberRequestDTO.ResetPasswordRequestDTO request);
 
+    //스크랩한 글 등록
+    MemberResponseDTO.AddScrapOrLikeResponseDTO addScrap(Long memberId, Long postId);
+
     //스크랩한 글 취소
     MemberResponseDTO.CancelScrapOrLikeResponseDTO cancelScrap(Long memberId, Long postId);
+
+    //공감한 글 등록
+    MemberResponseDTO.AddScrapOrLikeResponseDTO addLike(Long memberId, Long postId);
 
     //공감한 글 취소
     MemberResponseDTO.CancelScrapOrLikeResponseDTO cancelLike(Long memberId, Long postId);

--- a/src/main/java/com/onenth/OneNth/domain/member/service/memberService/MemberCommandServiceImpl.java
+++ b/src/main/java/com/onenth/OneNth/domain/member/service/memberService/MemberCommandServiceImpl.java
@@ -12,7 +12,9 @@ import com.onenth.OneNth.domain.member.repository.memberRepository.MemberReposit
 import com.onenth.OneNth.domain.member.service.EmailVerificationService.EmailService;
 import com.onenth.OneNth.domain.member.service.EmailVerificationService.EmailVerificationService;
 import com.onenth.OneNth.domain.post.entity.Like;
+import com.onenth.OneNth.domain.post.entity.Post;
 import com.onenth.OneNth.domain.post.entity.Scrap;
+import com.onenth.OneNth.domain.post.repository.PostRepository;
 import com.onenth.OneNth.domain.post.repository.likeRepository.LikeRepository;
 import com.onenth.OneNth.domain.post.repository.scrapRepository.ScrapRepository;
 import com.onenth.OneNth.domain.region.entity.Region;
@@ -40,6 +42,7 @@ public class MemberCommandServiceImpl implements MemberCommandService {
     private final EmailVerificationService emailVerificationService;
     private final EmailService emailService;
     private final JwtTokenProvider jwtTokenProvider;
+    private final PostRepository postRepository;
     private final ScrapRepository scrapRepository;
     private final LikeRepository likeRepository;
     private final MemberAlertSettingRepository memberAlertSettingRepository;
@@ -121,6 +124,35 @@ public class MemberCommandServiceImpl implements MemberCommandService {
         return MemberResponseDTO.PasswordResetResultDTO.builder().isSuccess(true).build();
     }
 
+
+    @Override
+    public MemberResponseDTO.AddScrapOrLikeResponseDTO addScrap(Long memberId, Long postId) {
+        // 게시글 존재 여부 확인
+        postRepository.findById(postId)
+                .orElseThrow(() -> new RuntimeException("존재하지 않는 게시글입니다."));
+
+        // 중복 스크랩 여부 확인
+        boolean exists = scrapRepository.existsByPostIdAndMemberId(postId, memberId);
+        if (exists) {
+            throw new RuntimeException("이미 스크랩한 글입니다.");
+        }
+
+        // 회원 여부 확인
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new RuntimeException("존재하지 않는 회원입니다."));
+
+        Scrap scrap = Scrap.builder()
+                .member(member)
+                .post(Post.builder().id(postId).build())
+                .build();
+
+        scrapRepository.save(scrap);
+
+        return MemberResponseDTO.AddScrapOrLikeResponseDTO.builder()
+                .isSuccess(true)
+                .build();
+    }
+
     @Override
     public MemberResponseDTO.CancelScrapOrLikeResponseDTO cancelScrap(Long memberId, Long postId) {
         Scrap scrap = scrapRepository.findByMemberIdAndPostId(memberId, postId)
@@ -129,6 +161,34 @@ public class MemberCommandServiceImpl implements MemberCommandService {
         scrapRepository.delete(scrap);
 
         return MemberResponseDTO.CancelScrapOrLikeResponseDTO.builder()
+                .isSuccess(true)
+                .build();
+    }
+
+    @Override
+    public MemberResponseDTO.AddScrapOrLikeResponseDTO addLike(Long memberId, Long postId) {
+        // 게시글 존재 여부 확인
+        postRepository.findById(postId)
+                .orElseThrow(() -> new RuntimeException("존재하지 않는 게시글입니다."));
+
+        // 중복 공감 여부 확인
+        boolean exists = likeRepository.findByMemberIdAndPostId(memberId, postId).isPresent();
+        if (exists) {
+            throw new RuntimeException("이미 공감한 글입니다.");
+        }
+
+        // 회원 여부 확인
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new RuntimeException("존재하지 않는 회원입니다."));
+
+        Like like = Like.builder()
+                .member(member)
+                .post(Post.builder().id(postId).build())
+                .build();
+
+        likeRepository.save(like);
+
+        return MemberResponseDTO.AddScrapOrLikeResponseDTO.builder()
                 .isSuccess(true)
                 .build();
     }

--- a/src/main/java/com/onenth/OneNth/domain/member/service/memberService/MemberCommandServiceImpl.java
+++ b/src/main/java/com/onenth/OneNth/domain/member/service/memberService/MemberCommandServiceImpl.java
@@ -3,7 +3,6 @@ package com.onenth.OneNth.domain.member.service.memberService;
 import com.onenth.OneNth.domain.member.converter.MemberConverter;
 import com.onenth.OneNth.domain.member.dto.MemberRequestDTO;
 import com.onenth.OneNth.domain.member.dto.MemberResponseDTO;
-import com.onenth.OneNth.domain.member.entity.EmailVerificationCode;
 import com.onenth.OneNth.domain.member.entity.Member;
 import com.onenth.OneNth.domain.member.entity.MemberAlertSetting;
 import com.onenth.OneNth.domain.member.entity.enums.MemberStatus;
@@ -29,8 +28,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.Collections;
-
-import static com.onenth.OneNth.domain.post.entity.QScrap.scrap;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/com/onenth/OneNth/domain/post/controller/PostRestController.java
+++ b/src/main/java/com/onenth/OneNth/domain/post/controller/PostRestController.java
@@ -1,6 +1,8 @@
 package com.onenth.OneNth.domain.post.controller;
 
+import com.onenth.OneNth.domain.member.dto.MemberResponseDTO;
 import com.onenth.OneNth.domain.member.entity.Member;
+import com.onenth.OneNth.domain.member.service.memberService.MemberCommandService;
 import com.onenth.OneNth.domain.region.entity.Region;
 import com.onenth.OneNth.domain.post.dto.PostDetailResponseDTO;
 import com.onenth.OneNth.domain.post.dto.PostListResponseDTO;
@@ -38,6 +40,7 @@ public class PostRestController {
     private final GeoCodingService geoCodingService;
     private final RegionRepository regionRepository;
     private final PostQueryService postQueryService;
+    private final MemberCommandService memberCommandService;
 
     @Operation(
             summary = "게시글 등록 API",
@@ -146,6 +149,7 @@ public class PostRestController {
     )
     @GetMapping("/search")
     public ApiResponse<List<PostListResponseDTO>> searchPosts(
+            @AuthUser Long memberId,
             @RequestParam PostType postType,
             @RequestParam(required = false) String regionName,
             @RequestParam(required = false) String keyword,
@@ -159,9 +163,7 @@ public class PostRestController {
         }
 
         Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
-
-
-        Page<PostListResponseDTO> pageResult = postQueryService.getPostList(postType, regionName, keyword, pageable);
+        Page<PostListResponseDTO> pageResult = postQueryService.getPostList(memberId, postType, regionName, keyword, pageable);
         List<PostListResponseDTO> contentList = pageResult.getContent();
 
         return ApiResponse.onSuccess(contentList);
@@ -178,12 +180,11 @@ public class PostRestController {
     )
     @GetMapping("/{postId}")
     public ApiResponse<PostDetailResponseDTO> getPostDetail(
-            @AuthUser Member member,
+            @AuthUser Long memberId,
             @PathVariable("postId") Long postId
             ) {
-
         postCommandService.increaseViewCount(postId);
-        PostDetailResponseDTO response = postQueryService.getPostDetail(postId, member);
+        PostDetailResponseDTO response = postQueryService.getPostDetail(postId, memberId);
         return ApiResponse.onSuccess(response);
     }
 
@@ -232,5 +233,75 @@ public class PostRestController {
     ) {
         postCommandService.delete(postId, memberId);
         return ApiResponse.of(SuccessStatus._OK, null);
+    }
+
+    @Operation(
+            summary = "게시글 공감 등록 API",
+            description = """
+    postId를 이용한 게시글 공감 등록 API입니다.
+    
+    - 쿼리파라미터 postId에 게시글 ID를 전달합니다.
+    - 중복 공감은 되지 않습니다.
+    """
+    )
+    @PostMapping("/{postId}/like")
+    public ApiResponse<MemberResponseDTO.AddScrapOrLikeResponseDTO> addLike(
+            @PathVariable Long postId,
+            @AuthUser Long memberId
+    ) {
+        MemberResponseDTO.AddScrapOrLikeResponseDTO response = memberCommandService.addLike(memberId, postId);
+        return ApiResponse.onSuccess(response);
+    }
+
+    @Operation(
+            summary = "게시글 공감 삭제 API",
+            description = """
+    postId를 이용한 게시글 공감 삭제 API입니다.
+    
+    - 쿼리파라미터 postId에 게시글 ID를 전달합니다.
+    """
+    )
+    @DeleteMapping("/{postId}/like")
+    public ApiResponse<MemberResponseDTO.CancelScrapOrLikeResponseDTO> cancelLike(
+            @PathVariable Long postId,
+            @AuthUser Long memberId
+    ) {
+        MemberResponseDTO.CancelScrapOrLikeResponseDTO response = memberCommandService.cancelLike(memberId, postId);
+        return ApiResponse.onSuccess(response);
+    }
+
+    @Operation(
+            summary = "게시글 스크랩 등록 API",
+            description = """
+    postId를 이용한 게시글 스크랩 등록 API입니다.
+    
+    - 쿼리파라미터 postId에 게시글 ID를 전달합니다.
+    - 중복 스크랩은 되지 않습니다.
+    """
+    )
+    @PostMapping("/{postId}/scrap")
+    public ApiResponse<MemberResponseDTO.AddScrapOrLikeResponseDTO> addScrap(
+            @PathVariable Long postId,
+            @AuthUser Long memberId
+    ) {
+        MemberResponseDTO.AddScrapOrLikeResponseDTO response = memberCommandService.addScrap(memberId, postId);
+        return ApiResponse.onSuccess(response);
+    }
+
+    @Operation(
+            summary = "게시글 스크랩 삭제 API",
+            description = """
+    postId를 이용한 게시글 스크랩 삭제 API입니다.
+    
+    - 쿼리파라미터 postId에 게시글 ID를 전달합니다.
+    """
+    )
+    @DeleteMapping("/{postId}/scrap")
+    public ApiResponse<MemberResponseDTO.CancelScrapOrLikeResponseDTO> cancelScrap(
+            @PathVariable Long postId,
+            @AuthUser Long memberId
+    ) {
+        MemberResponseDTO.CancelScrapOrLikeResponseDTO response = memberCommandService.cancelScrap(memberId, postId);
+        return ApiResponse.onSuccess(response);
     }
 }

--- a/src/main/java/com/onenth/OneNth/domain/post/controller/PostRestController.java
+++ b/src/main/java/com/onenth/OneNth/domain/post/controller/PostRestController.java
@@ -1,7 +1,6 @@
 package com.onenth.OneNth.domain.post.controller;
 
 import com.onenth.OneNth.domain.member.dto.MemberResponseDTO;
-import com.onenth.OneNth.domain.member.entity.Member;
 import com.onenth.OneNth.domain.member.service.memberService.MemberCommandService;
 import com.onenth.OneNth.domain.region.entity.Region;
 import com.onenth.OneNth.domain.post.dto.PostDetailResponseDTO;

--- a/src/main/java/com/onenth/OneNth/domain/post/entity/Post.java
+++ b/src/main/java/com/onenth/OneNth/domain/post/entity/Post.java
@@ -1,7 +1,6 @@
 package com.onenth.OneNth.domain.post.entity;
 
 import com.onenth.OneNth.domain.common.BaseEntity;
-import com.onenth.OneNth.domain.common.QBaseEntity;
 import com.onenth.OneNth.domain.post.entity.enums.PostType;
 import com.onenth.OneNth.domain.region.entity.Region;
 import com.onenth.OneNth.domain.member.entity.Member;

--- a/src/main/java/com/onenth/OneNth/domain/post/service/PostQueryService.java
+++ b/src/main/java/com/onenth/OneNth/domain/post/service/PostQueryService.java
@@ -1,6 +1,5 @@
 package com.onenth.OneNth.domain.post.service;
 
-import com.onenth.OneNth.domain.member.entity.Member;
 import com.onenth.OneNth.domain.post.dto.PostDetailResponseDTO;
 import com.onenth.OneNth.domain.post.dto.PostListResponseDTO;
 import com.onenth.OneNth.domain.post.entity.enums.PostType;

--- a/src/main/java/com/onenth/OneNth/domain/post/service/PostQueryService.java
+++ b/src/main/java/com/onenth/OneNth/domain/post/service/PostQueryService.java
@@ -11,10 +11,11 @@ import org.springframework.data.domain.Pageable;
 public interface PostQueryService {
 
     // 게시글 상세 조회
-    PostDetailResponseDTO getPostDetail(Long postId, Member member);
+    PostDetailResponseDTO getPostDetail(Long postId, Long memberId);
 
     // 게시글 목록 조회 (regionName 또는 keyword로)
     Page<PostListResponseDTO> getPostList(
+            Long memberId,
             PostType postType,
             String regionName,
             String keyword,

--- a/src/main/java/com/onenth/OneNth/domain/post/service/PostQueryServiceImpl.java
+++ b/src/main/java/com/onenth/OneNth/domain/post/service/PostQueryServiceImpl.java
@@ -1,6 +1,5 @@
 package com.onenth.OneNth.domain.post.service;
 
-import com.onenth.OneNth.domain.member.entity.Member;
 import com.onenth.OneNth.domain.post.dto.PostDetailResponseDTO;
 import com.onenth.OneNth.domain.post.dto.PostListResponseDTO;
 import com.onenth.OneNth.domain.post.entity.Post;

--- a/src/main/java/com/onenth/OneNth/domain/post/service/PostQueryServiceImpl.java
+++ b/src/main/java/com/onenth/OneNth/domain/post/service/PostQueryServiceImpl.java
@@ -33,6 +33,7 @@ public class PostQueryServiceImpl implements PostQueryService {
 
     @Override
     public Page<PostListResponseDTO> getPostList(
+            Long memberId,
             PostType postType,
             String regionName,
             String keyword,
@@ -52,10 +53,12 @@ public class PostQueryServiceImpl implements PostQueryService {
             }
         }
 
-        return posts.map(this::toPostListDTO);
+        return posts.map(post -> toPostListDTO(post, memberId));
     }
 
-    private PostListResponseDTO toPostListDTO(Post post) {
+    private PostListResponseDTO toPostListDTO(Post post, Long memberId) {
+        boolean scrapStatus = ScrapRepository.existsByPostIdAndMemberId(post.getId(), memberId);
+
         return PostListResponseDTO.builder()
                 .postId(post.getId())
                 .title(post.getTitle())
@@ -63,7 +66,7 @@ public class PostQueryServiceImpl implements PostQueryService {
                 .commentCount(post.getPostComment().size())
                 .likeCount(post.getLike().size())
                 .viewCount(post.getViewCount())
-                .scrapStatus(false) // 로그인 사용자 로직 필요 시 수정
+                .scrapStatus(scrapStatus)
                 .createdAt(post.getCreatedAt().toString())
                 .build();
     }
@@ -72,13 +75,13 @@ public class PostQueryServiceImpl implements PostQueryService {
         return content.length() > 50 ? content.substring(0, 50) + "..." : content;
     }
 
-    public PostDetailResponseDTO getPostDetail(Long postId, Member member) {
+    public PostDetailResponseDTO getPostDetail(Long postId, Long memberId) {
         Post post = postRepository.findByIdWithMemberAndRegion(postId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.NOT_FOUND_POST));
 
         int commentCount = (int) CommentRepository.countByPost(post);
         int likeCount = (int) LikeRepository.countByPost(post);
-        boolean scrapStatus = ScrapRepository.existsByPostIdAndMemberId(postId, member.getId());
+        boolean scrapStatus = ScrapRepository.existsByPostIdAndMemberId(postId, memberId);
         List<String> imageUrls = imageRepository.findUrlsByPost(post);
 
         return PostDetailResponseDTO.builder()


### PR DESCRIPTION
## 📌 작업 내용

### **작업 API 스웨거 명세**
<img width="1216" height="347" alt="image" src="https://github.com/user-attachments/assets/5c18e831-6856-485a-a267-6b78f8973b23" />

> 

>###  **1. 게시글 공감 등록 API 구현**
> - postId를 이용한 게시글 공감 등록 API입니다.
> - 쿼리파라미터 postId에 게시글 ID를 전달합니다.
> - 중복 공감은 되지 않습니다.

>###  **2. 게시글 공감 삭제 API 구현**
> - postId를 이용한 게시글 공감 삭제 API입니다.
> - 쿼리파라미터 postId에 게시글 ID를 전달합니다.

> ### **3. 게시글 스크랩 등록 API 구현**
> - postId를 이용한 게시글 스크랩 등록 API입니다.
> - 쿼리파라미터 postId에 게시글 ID를 전달합니다.
> - 중복 스크랩은 되지 않습니다.

> ### **4. 게시글 스크랩 삭제 API 구현**
> - postId를 이용한 게시글 스크랩 삭제 API입니다.
> - 쿼리파라미터 postId에 게시글 ID를 전달합니다.

## ✨ 참고 사항

> - 게시글 목록 조회와 상세 조회 API에도 댓글 수, 스크랩 수, 공감수가 모두 반영되도록 수정했습니다.

## 🧩 연관 이슈

> close #84 


<br>