### PR TITLE
🐛 [Fix] 함께나눠요 상품검색시 지역필터링 미적용 문제 해결

### DIFF
--- a/src/main/java/com/onenth/OneNth/domain/product/converter/SharingItemConverter.java
+++ b/src/main/java/com/onenth/OneNth/domain/product/converter/SharingItemConverter.java
@@ -33,7 +33,6 @@ public class SharingItemConverter {
                 .expirationDate(expirationDate)
                 .isAvailable(isAvailable)
                 .purchaseMethod(purchaseMethod)
-                .regionId(regionId)
                 .tags(tags)
                 .build();
     }

--- a/src/main/java/com/onenth/OneNth/domain/product/dto/SharingItemRequestDTO.java
+++ b/src/main/java/com/onenth/OneNth/domain/product/dto/SharingItemRequestDTO.java
@@ -44,9 +44,6 @@ public class SharingItemRequestDTO {
     @JsonProperty("purchaseMethod")
     private PurchaseMethod purchaseMethod;
 
-    @NotNull
-    private Long regionId;
-
     @Size(min = 1, max = 3)
     private List<@NotBlank String> imageUrls;
 

--- a/src/main/java/com/onenth/OneNth/domain/product/entity/PurchaseItem.java
+++ b/src/main/java/com/onenth/OneNth/domain/product/entity/PurchaseItem.java
@@ -9,6 +9,7 @@ import com.onenth.OneNth.domain.region.entity.Region;
 import com.onenth.OneNth.domain.member.entity.Member;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.BatchSize;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -69,6 +70,7 @@ public class PurchaseItem extends BaseEntity {
             joinColumns = @JoinColumn(name = "purchase_item_id"),
             inverseJoinColumns = @JoinColumn(name = "tag_id")
     )
+    @BatchSize(size=100)
     private List<Tag> tags = new ArrayList<>();// +
 
     @Column

--- a/src/main/java/com/onenth/OneNth/domain/product/entity/SharingItem.java
+++ b/src/main/java/com/onenth/OneNth/domain/product/entity/SharingItem.java
@@ -10,6 +10,7 @@ import com.onenth.OneNth.domain.region.entity.Region;
 import com.onenth.OneNth.domain.member.entity.Member;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.BatchSize;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -73,6 +74,7 @@ public class SharingItem extends BaseEntity {
             joinColumns = @JoinColumn(name = "sharing_item_id"),
             inverseJoinColumns = @JoinColumn(name = "tag_id")
     )
+    @BatchSize(size=100)
     private List<Tag> tags = new ArrayList<>();
 
     // +

--- a/src/main/java/com/onenth/OneNth/domain/product/repository/itemRepository/purchase/PurchaseItemRepository.java
+++ b/src/main/java/com/onenth/OneNth/domain/product/repository/itemRepository/purchase/PurchaseItemRepository.java
@@ -13,7 +13,7 @@ import java.util.Optional;
 public interface PurchaseItemRepository  extends JpaRepository<PurchaseItem, Long>, PurchaseItemRepositoryCustom {
     List<PurchaseItem> findByMember(Member member);
 
-    // 상품명(지역 필터링)
+    // 상품단건조회
     @Query("""
     SELECT p
     FROM PurchaseItem p

--- a/src/main/java/com/onenth/OneNth/domain/product/repository/itemRepository/sharing/SharingItemRepository.java
+++ b/src/main/java/com/onenth/OneNth/domain/product/repository/itemRepository/sharing/SharingItemRepository.java
@@ -2,6 +2,7 @@ package com.onenth.OneNth.domain.product.repository.itemRepository.sharing;
 
 import com.onenth.OneNth.domain.member.entity.Member;
 import com.onenth.OneNth.domain.product.entity.SharingItem;
+import com.onenth.OneNth.domain.product.entity.enums.Status;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -18,13 +19,16 @@ public interface SharingItemRepository extends JpaRepository<SharingItem, Long>,
     @Query("""
     SELECT s
     FROM SharingItem s
+    JOIN FETCH s.region
     WHERE LOWER(s.title) LIKE LOWER(CONCAT('%', :keyword, '%'))
       AND s.region.id IN :regionIds
+      AND s.status IN :statuses
     """)
-    List<SharingItem> searchByTitleAndRegion(@Param("keyword") String keyword, @Param("regionIds") List<Integer> regionIds);
-
-    // 상품명(전체 조회)
-    List<SharingItem> findByTitleContainingIgnoreCase(String keyword);
+    List<SharingItem> searchByTitleAndRegion(
+            @Param("keyword") String keyword,
+            @Param("regionIds") List<Integer> regionIds,
+            @Param("statuses") List<Status> statuses
+    );
 
     @Query("""
     SELECT s

--- a/src/main/java/com/onenth/OneNth/domain/product/repository/itemRepository/sharing/SharingItemRepositoryImpl.java
+++ b/src/main/java/com/onenth/OneNth/domain/product/repository/itemRepository/sharing/SharingItemRepositoryImpl.java
@@ -1,9 +1,6 @@
 package com.onenth.OneNth.domain.product.repository.itemRepository.sharing;
 
-import com.onenth.OneNth.domain.product.entity.QPurchaseItem;
-import com.onenth.OneNth.domain.product.entity.QSharingItem;
-import com.onenth.OneNth.domain.product.entity.QTag;
-import com.onenth.OneNth.domain.product.entity.SharingItem;
+import com.onenth.OneNth.domain.product.entity.*;
 import com.onenth.OneNth.domain.product.entity.enums.ItemCategory;
 import com.onenth.OneNth.domain.product.entity.enums.Status;
 import com.onenth.OneNth.domain.region.entity.QRegion;
@@ -22,14 +19,19 @@ public class SharingItemRepositoryImpl implements SharingItemRepositoryCustom {
     public List<SharingItem> findByRegionAndTag(List<Integer> regionIds, String tag) {
         QSharingItem item = QSharingItem.sharingItem;
         QTag qTag = QTag.tag;
+        QItemImage image = QItemImage.itemImage;
+        QRegion region = QRegion.region;
 
         return queryFactory
                 .selectFrom(item)
+                .distinct()
+                .join(item.region, region).fetchJoin()
+                .leftJoin(item.itemImages, image).fetchJoin()
                 .join(item.tags, qTag)
                 .where(
-                        item.region.id.in(regionIds)
-                                .and(qTag.name.eq(tag))
-                                .and(item.status.in(Status.DEFAULT, Status.IN_PROGRESS))
+                        item.region.id.in(regionIds),
+                        qTag.name.eq(tag),
+                        item.status.in(Status.DEFAULT, Status.IN_PROGRESS)
                 )
                 .fetch();
     }
@@ -37,11 +39,18 @@ public class SharingItemRepositoryImpl implements SharingItemRepositoryCustom {
     @Override
     public List<SharingItem> findByRegionAndCategory(List<Integer> regionIds, String category) {
         QSharingItem item = QSharingItem.sharingItem;
-        return queryFactory.selectFrom(item)
+        QItemImage image = QItemImage.itemImage;
+        QRegion region = QRegion.region;
+
+        return queryFactory
+                .selectFrom(item)
+                .distinct()
+                .join(item.region, region).fetchJoin()
+                .leftJoin(item.itemImages, image).fetchJoin()
                 .where(
-                        item.region.id.in(regionIds)
-                                .and(item.itemCategory.eq(ItemCategory.valueOf(category.toUpperCase())))
-                                .and(item.status.in(Status.DEFAULT, Status.IN_PROGRESS))
+                        item.region.id.in(regionIds),
+                        item.itemCategory.eq(ItemCategory.valueOf(category.toUpperCase())),
+                        item.status.in(Status.DEFAULT, Status.IN_PROGRESS)
                 )
                 .fetch();
     }


### PR DESCRIPTION
## 📌 작업 내용

> 함께나눠요 상품검색 필터링 전반 개선 및 등록 시 리전아이디 요청바디 제거

## ✨ 참고 사항

> sharingitem&purchaseitem에 배치사이즈 추가하여 fetch join시 최대갯수 지정
> (IN 절에 size 보다 더 많은 요소가 들어가야 한다면 여러 개의 IN 쿼리로 나누도록 지정했습니다)
## 🧩 연관 이슈

> close #89 


<br>