### PR TITLE
✨[Feat] 카카오 로그인 로직 수정

### DIFF
--- a/src/main/java/com/onenth/OneNth/domain/auth/controller/KakaoAuthController.java
+++ b/src/main/java/com/onenth/OneNth/domain/auth/controller/KakaoAuthController.java
@@ -25,7 +25,7 @@ public class KakaoAuthController {
      */
     @Operation(
             summary = "카카오 인가 코드를 받는 API",
-            description = "카카오 로그인을 위해 인가코드를 프론트에서 받습니다. 인가코드로 사용자 정보를 받아서 로그인완료/회원가입 요청으로 분기됩니다."
+            description = "카카오 로그인을 위해 액세스 토큰을 프론트에서 받습니다. 액세스 토큰을 이용해서 사용자 정보를 받아서 로그인완료/회원가입 요청으로 분기됩니다."
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),

--- a/src/main/java/com/onenth/OneNth/domain/auth/dto/KakaoRequestDTO.java
+++ b/src/main/java/com/onenth/OneNth/domain/auth/dto/KakaoRequestDTO.java
@@ -11,8 +11,8 @@ public class KakaoRequestDTO {
     @Getter
     @Setter
     public static class KakaoLoginRequestDTO {
-        @NotBlank(message = "인가코드는 필수입니다.")
-        private String code; // 카카오 인가 코드
+        @NotBlank(message = "access token은 필수입니다.")
+        private String accessToken;  // 카카오 accessToken으로 변경
     }
 
     @Getter

--- a/src/main/java/com/onenth/OneNth/domain/auth/service/KakaoAuthService.java
+++ b/src/main/java/com/onenth/OneNth/domain/auth/service/KakaoAuthService.java
@@ -30,10 +30,10 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class KakaoAuthService {
 
-    @Value("${kakao.redirect_uri}")
-    private String redirectUri;
-    @Value("${kakao.client_id}")
-    private String clientId;
+//    @Value("${kakao.redirect_uri}")
+//    private String redirectUri;
+//    @Value("${kakao.client_id}")
+//    private String clientId;
 
     private final MemberRepository memberRepository;
     private final JwtTokenProvider jwtTokenProvider;
@@ -43,7 +43,7 @@ public class KakaoAuthService {
 
     // 카카오 로그인 요청 처리 서비스
     public KakaoResponseDTO.KakaoLoginResponseDTO processKakaoLogin (KakaoRequestDTO.KakaoLoginRequestDTO request) {
-        String accessToken = getKakaoAccessToken(request.getCode());
+        String accessToken = request.getAccessToken();
         KakaoUserInfo userInfo = getUserInfo(accessToken);
 
         Optional<Member> member = memberRepository.findBySocialIdAndLoginType(userInfo.getId(), LoginType.KAKAO);
@@ -124,28 +124,6 @@ public class KakaoAuthService {
                 .build();
     }
 
-    //프론트에서 받은 인가 코드로 access token 요청하는 메서드
-    private String getKakaoAccessToken(String authorizationCode) {
-        RestTemplate restTemplate = new RestTemplate();
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
-
-        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
-        params.add("grant_type", "authorization_code");
-        params.add("client_id", clientId);
-        params.add("redirect_uri", redirectUri);
-        params.add("code", authorizationCode);
-
-        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(params, headers);
-        ResponseEntity<Map> response = restTemplate.postForEntity(
-                "https://kauth.kakao.com/oauth/token",
-                request,
-                Map.class
-        );
-
-        return (String) response.getBody().get("access_token");
-    }
-
     // 카카오에서 발급받은 access 토큰을 이용해서 사용자 정보 요청하는 메서드
     private KakaoUserInfo getUserInfo(String accessToken) {
         RestTemplate restTemplate = new RestTemplate();
@@ -170,4 +148,28 @@ public class KakaoAuthService {
                 String.valueOf(body.get("id"))
         );
     }
+
+
+//    //프론트에서 받은 인가 코드로 access token 요청하는 메서드
+//    private String getKakaoAccessToken(String authorizationCode) {
+//        RestTemplate restTemplate = new RestTemplate();
+//        HttpHeaders headers = new HttpHeaders();
+//        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+//
+//        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+//        params.add("grant_type", "authorization_code");
+//        params.add("client_id", clientId);
+//        params.add("redirect_uri", redirectUri);
+//        params.add("code", authorizationCode);
+//
+//        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(params, headers);
+//        ResponseEntity<Map> response = restTemplate.postForEntity(
+//                "https://kauth.kakao.com/oauth/token",
+//                request,
+//                Map.class
+//        );
+//
+//        return (String) response.getBody().get("access_token");
+//    }
+
 }

--- a/src/main/java/com/onenth/OneNth/domain/post/repository/scrapRepository/ScrapRepository.java
+++ b/src/main/java/com/onenth/OneNth/domain/post/repository/scrapRepository/ScrapRepository.java
@@ -5,6 +5,7 @@ import com.onenth.OneNth.domain.post.entity.Post;
 import com.onenth.OneNth.domain.post.entity.Scrap;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -13,11 +14,7 @@ import java.util.Optional;
 
 public interface ScrapRepository extends JpaRepository<Scrap, Long> {
 
-    @Query("SELECT s FROM Scrap s " +
-            "JOIN FETCH s.post p " +
-            "JOIN FETCH p.region r " +
-            "WHERE s.member.id = :memberId " +
-            "ORDER BY s.createdAt DESC ")
+    @EntityGraph(attributePaths = {"post", "post.region"})
     Page<Scrap> findByMemberId(@Param("memberId") Long memberId, Pageable pageable);
 
     Optional<Scrap> findByMemberIdAndPostId(Long memberId, Long postId);


### PR DESCRIPTION
## 📌 작업 내용

> ### 1. 카카오 로그인 로직 수정
>- 프론트와 소통으로 액세스 토큰까지 프론트에서 받는 로직으로 변경하는 것으로 결정했습니다.
>- 따라서 카카오 인가 토큰만 넘겨받는 로직에서 카카오 액세스 토큰을 받는 로직으로 수정했습니다.

> ### 2. 내가 스크랩한 글 페이지 조회 SQL 최적화
>- fetch join과 pageable의 충돌 가능성을 감지해서 @EntityGraph로 최적화
>- 로직은 변화 없고 쿼리 조회 코드만 리팩터링

## ✨ 참고 사항

> 수정사항이 보인다면 리뷰 남겨주세요.

## 🧩 연관 이슈

>  close #102


<br>