### PR TITLE
♻️ [Recycle] 패치조인 최적화, 페이징왜곡 위험성 제거 및 불필요한 코드 삭제

### DIFF
--- a/src/main/java/com/onenth/OneNth/domain/product/converter/SharingItemConverter.java
+++ b/src/main/java/com/onenth/OneNth/domain/product/converter/SharingItemConverter.java
@@ -22,7 +22,6 @@ public class SharingItemConverter {
             LocalDate expirationDate,
             Boolean isAvailable,
             PurchaseMethod purchaseMethod,
-            Long regionId,
             List<String> tags
     ) {
         return SharingItemRequestDTO.builder()

--- a/src/main/java/com/onenth/OneNth/domain/product/repository/itemRepository/purchase/PurchaseItemRepositoryImpl.java
+++ b/src/main/java/com/onenth/OneNth/domain/product/repository/itemRepository/purchase/PurchaseItemRepositoryImpl.java
@@ -17,8 +17,6 @@ import com.querydsl.core.types.dsl.BooleanExpression;
 
 import java.util.List;
 
-
-@Slf4j
 @Repository
 @RequiredArgsConstructor
 public class PurchaseItemRepositoryImpl implements PurchaseItemRepositoryCustom {
@@ -70,7 +68,6 @@ public class PurchaseItemRepositoryImpl implements PurchaseItemRepositoryCustom 
         QPurchaseItem item = QPurchaseItem.purchaseItem;
         QRegion region = QRegion.region;
         QItemImage image = QItemImage.itemImage;
-        QTag tag = QTag.tag;
 
         String cleanKeyword = regionName.trim();
 
@@ -79,7 +76,6 @@ public class PurchaseItemRepositoryImpl implements PurchaseItemRepositoryCustom 
                 .distinct()
                 .join(item.region, region).fetchJoin()
                 .leftJoin(item.itemImages, image).fetchJoin()
-                .join(item.tags, tag)
                 .where(
                         region.regionName.like("%" + cleanKeyword + "%"),
                         item.status.in(Status.DEFAULT, Status.IN_PROGRESS)
@@ -89,7 +85,6 @@ public class PurchaseItemRepositoryImpl implements PurchaseItemRepositoryCustom 
 
     @Override
     public List<PurchaseItem> searchByTitleAndRegion(String keyword, List<Integer> regionIds) {
-        log.info("QueryDSL searchByTitleAndRegion 실행");
         QPurchaseItem item = QPurchaseItem.purchaseItem;
         QItemImage image = QItemImage.itemImage;
         QTag tag = QTag.tag;
@@ -101,9 +96,6 @@ public class PurchaseItemRepositoryImpl implements PurchaseItemRepositoryCustom 
         if (regionIds != null && !regionIds.isEmpty()) {
             builder.and(item.region.id.in(regionIds));
         }
-
-        log.info("regionIds = {}", regionIds);
-        log.info("필터링된 쿼리 조건: name LIKE '%{}%', region.id in {}", keyword, regionIds);
 
         return queryFactory
                 .selectFrom(item)

--- a/src/main/java/com/onenth/OneNth/domain/product/repository/itemRepository/sharing/SharingItemRepositoryCustom.java
+++ b/src/main/java/com/onenth/OneNth/domain/product/repository/itemRepository/sharing/SharingItemRepositoryCustom.java
@@ -7,7 +7,7 @@ import java.util.List;
 public interface SharingItemRepositoryCustom {
 
     // 태그(지역필터링) 검색
-    List<SharingItem> findByRegionAndTag(List<Integer> regionIds, String tag);
+    List<SharingItem> findByRegionsAndTag(List<Integer> regionIds, String tag);
     // 카테고리(지역필터링) 검색
     List<SharingItem> findByRegionAndCategory(List<Integer> regionIds, String category);
     // 지역명(지역 필터링x) 검색

--- a/src/main/java/com/onenth/OneNth/domain/product/repository/itemRepository/sharing/SharingItemRepositoryImpl.java
+++ b/src/main/java/com/onenth/OneNth/domain/product/repository/itemRepository/sharing/SharingItemRepositoryImpl.java
@@ -16,7 +16,7 @@ public class SharingItemRepositoryImpl implements SharingItemRepositoryCustom {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public List<SharingItem> findByRegionAndTag(List<Integer> regionIds, String tag) {
+    public List<SharingItem> findByRegionsAndTag(List<Integer> regionIds, String tag) {
         QSharingItem item = QSharingItem.sharingItem;
         QTag qTag = QTag.tag;
         QItemImage image = QItemImage.itemImage;
@@ -65,6 +65,7 @@ public class SharingItemRepositoryImpl implements SharingItemRepositoryCustom {
 
         return queryFactory
                 .selectFrom(item)
+                .distinct()
                 .join(item.region, region).fetchJoin()
                 .leftJoin(item.itemImages, image).fetchJoin()
                 .where(

--- a/src/main/java/com/onenth/OneNth/domain/product/repository/itemRepository/sharing/SharingItemRepositoryImpl.java
+++ b/src/main/java/com/onenth/OneNth/domain/product/repository/itemRepository/sharing/SharingItemRepositoryImpl.java
@@ -59,12 +59,14 @@ public class SharingItemRepositoryImpl implements SharingItemRepositoryCustom {
     public List<SharingItem> findByRegionName(String regionName) {
         QSharingItem item = QSharingItem.sharingItem;
         QRegion region = QRegion.region;
+        QItemImage image = QItemImage.itemImage;
 
         String cleanKeyword = regionName.trim();
 
         return queryFactory
                 .selectFrom(item)
                 .join(item.region, region).fetchJoin()
+                .leftJoin(item.itemImages, image).fetchJoin()
                 .where(
                         region.regionName.like("%" + cleanKeyword + "%")
                                 .and(item.status.in(Status.DEFAULT, Status.IN_PROGRESS))

--- a/src/main/java/com/onenth/OneNth/domain/product/service/PurchaseItemService.java
+++ b/src/main/java/com/onenth/OneNth/domain/product/service/PurchaseItemService.java
@@ -82,17 +82,38 @@ public class PurchaseItemService {
         // 회원 및 지역 조회
         Member member = Member.builder().id(userId).build();
 
-        // 등록한 주소명 문자열 기반으로 region 찾아 매핑
-        GeoCodingResult geo = geoCodingService.getCoordinatesFromAddress(dto.getPurchaseLocation());
-        if (geo == null) {
-            throw new IllegalArgumentException("유효한 주소를 입력해주세요.");
+        GeoCodingResult geo = null;
+        Region region;
+
+        // 장소입력 유효성
+        if (dto.getPurchaseMethod() == PurchaseMethod.OFFLINE) {
+            if (dto.getPurchaseLocation() == null || dto.getPurchaseLocation().isBlank()) {
+                throw new IllegalArgumentException("오프라인 구매는 거래 장소를 반드시 입력해야 합니다.");
+            }
+            geo = geoCodingService.getCoordinatesFromAddress(dto.getPurchaseLocation());
+            if (geo == null) throw new IllegalArgumentException("유효한 주소를 입력해주세요.");
+
+            region = regionRepository.findByRegionNameContaining(dto.getPurchaseLocation())
+                    .stream().findFirst()
+                    .orElseThrow(() -> new IllegalArgumentException("입력한 주소에 해당하는 지역 정보를 찾을 수 없습니다."));
+        } else { // ONLINE
+            if (dto.getPurchaseLocation() != null && !dto.getPurchaseLocation().isBlank()) {
+                throw new IllegalArgumentException("온라인 구매는 거래 장소를 입력할 수 없습니다.");
+            }
+            Region mainRegion = memberRegionRepository.findByMemberId(userId)
+                    .stream().findFirst()
+                    .orElseThrow(() -> new IllegalStateException("대표 지역이 없습니다."))
+                    .getRegion();
+
+            if (mainRegion.getLatitude() == null || mainRegion.getLongitude() == null) {
+                GeoCodingResult g = geoCodingService.getCoordinatesFromAddress(mainRegion.getRegionName());
+                if (g == null) throw new IllegalStateException("대표 지역의 위도/경도 정보를 찾을 수 없습니다.");
+                mainRegion.setLatitude(g.getLatitude());
+                mainRegion.setLongitude(g.getLongitude());
+                regionRepository.save(mainRegion);
+            }
+            region = mainRegion;          // ★ ONLINE region 확정
         }
-
-        Region region = regionRepository.findByRegionNameContaining(dto.getPurchaseLocation())
-                .stream()
-                .findFirst()
-                .orElseThrow(() -> new IllegalArgumentException("입력한 주소에 해당하는 지역 정보를 찾을 수 없습니다."));
-
 
         // 태그 유효성 검사 및 저장
         List<Tag> tagEntities = dto.getTags().stream()
@@ -109,29 +130,12 @@ public class PurchaseItemService {
             throw new IllegalArgumentException("태그는 최대 5개까지 입력 가능합니다.");
         }
 
-        // 장소입력 유효성
-        if (dto.getPurchaseMethod() == PurchaseMethod.OFFLINE) {
-            if (dto.getPurchaseLocation() == null || dto.getPurchaseLocation().isBlank()) {
-                throw new IllegalArgumentException("오프라인 구매는 거래 장소를 반드시 입력해야 합니다.");
-            }
-
-            geo = geoCodingService.getCoordinatesFromAddress(dto.getPurchaseLocation());
-            if (geo == null) {
-                throw new IllegalArgumentException("유효한 주소를 입력해주세요.");
-            }
-        } else {
-            // 온라인일 경우엔 주소 없어야 함
-            if (dto.getPurchaseLocation() != null && !dto.getPurchaseLocation().isBlank()) {
-                throw new IllegalArgumentException("온라인 구매는 거래 장소를 입력할 수 없습니다.");
-            }
-        }
-
         // PurchaseItem 생성
         PurchaseItem purchaseItem = PurchaseItem.builder()
                 .name(dto.getName())
                 .purchaseMethod(dto.getPurchaseMethod())
                 .itemCategory(dto.getItemCategory())
-                .purchaseLocation(dto.getPurchaseUrl())
+                .purchaseLocation(dto.getPurchaseLocation())
                 .expirationDate(dto.getExpirationDate())
                 .price(dto.getPrice())
                 .status(Status.DEFAULT)

--- a/src/main/java/com/onenth/OneNth/domain/product/service/SharingItemService.java
+++ b/src/main/java/com/onenth/OneNth/domain/product/service/SharingItemService.java
@@ -79,6 +79,7 @@ public class SharingItemService {
         GeoCodingResult geo = null;
         Region region;
 
+        // 장소입력 유효성
         if (dto.getPurchaseMethod() == PurchaseMethod.OFFLINE) {
             if (dto.getSharingLocation() == null || dto.getSharingLocation().isBlank()) {
                 throw new IllegalArgumentException("오프라인 구매는 거래 장소를 반드시 입력해야 합니다.");
@@ -105,6 +106,7 @@ public class SharingItemService {
                     .getRegion();
         }
 
+        // 태그 유효성 검사 및 저장
         List<Tag> tagEntities = dto.getTags().stream()
                 .peek(tag -> {
                     if (!tag.startsWith("#")) {
@@ -151,6 +153,7 @@ public class SharingItemService {
                 .build();
         sharingItem.getTags().addAll(tagEntities);
 
+        // ONLINE이면 대표지역 위도경도 설정
         if (dto.getPurchaseMethod() == PurchaseMethod.ONLINE) {
             if (region.getLatitude() == null || region.getLongitude() == null) {
                 GeoCodingResult regionGeo = geoCodingService.getCoordinatesFromAddress(region.getRegionName());

--- a/src/main/java/com/onenth/OneNth/domain/product/service/SharingItemService.java
+++ b/src/main/java/com/onenth/OneNth/domain/product/service/SharingItemService.java
@@ -221,7 +221,7 @@ public class SharingItemService {
         if (keyword.startsWith("#")) {
             // 태그 검색 (설정 지역 내)
             String tag = keyword;
-            items = sharingItemRepository.findByRegionAndTag(regionIds, tag);
+            items = sharingItemRepository.findByRegionsAndTag(regionIds, tag);
         } else if (isCategory(keyword)) {
             // 카테고리 검색 (설정 지역 내)
             items = sharingItemRepository.findByRegionAndCategory(regionIds, keyword);


### PR DESCRIPTION
## 📌 작업 내용

> - ONLINE/OFFLINE 분기별 주소·지역 처리 로직 통일
  - ONLINE: 거래 장소 입력 금지, 대표지역 사용, 좌표 자동 설정
  - OFFLINE: 거래 장소 필수, 지오코딩 기반 지역 매핑
- region 조회를 구매방식별 분기 내부로 이동하여 ONLINE 시 불필요한 조회 제거
- purchaseLocation 저장 정책 명확화 (ONLINE은 null 저장)
- 좌표 세팅 로직 분기별로 명확하게 분리
- 함께나눠요/같이사요 등록 로직 구조 일관성 확보

## ✨ 참고 사항

> x

## 🧩 연관 이슈

> close #110 


<br>