### PR TITLE
✨[Feat] 게시글 조회 시, 이미지 관련 응답 추가

### DIFF
--- a/src/main/java/com/onenth/OneNth/domain/post/controller/PostRestController.java
+++ b/src/main/java/com/onenth/OneNth/domain/post/controller/PostRestController.java
@@ -138,7 +138,7 @@ public class PostRestController {
             summary = "게시글 목록 조회 API",
             description = """
     게시판 종류(postType), 지역명(regionName), 키워드(keyword)를 이용한 게시글 목록 조회 API입니다.
-    응답으로 '게시글Id', '제목', '본문 미리보기(최대 50자)', '댓글수', '좋아요수', '조회수', '스크랩 상태', '생성 시간'을 제공합니다.
+    응답으로 '게시글Id', '제목', '본문 미리보기(최대 50자)', '댓글수', '좋아요수', '조회수', '스크랩 상태', '게시글 이미지 URL', '생성 시간'을 제공합니다.
     
     - postType은 필수입니다: 'LIFE_TIP', 'DISCOUNT', 'RESTAURANT'
     - regionName와 keyword는 선택입니다. (단 지역명의 경우, LIFE_TIP에서는 무시됩니다)
@@ -174,7 +174,7 @@ public class PostRestController {
     @Operation(
             summary = "게시글 상세 조회 API",
             description = """
-    postId를 이용한 게시글의 상세 정보 조회 API입니다. 응답으로 'postId', '작성자 닉네임', '지역명'(LIFE_TIP의 경우, null), '제목', '내용', '이미지 url', '스크랩 상태', '공감,댓글,조회수', '생성시간'을 제공합니다.
+    postId를 이용한 게시글의 상세 정보 조회 API입니다. 응답으로 'postId', '작성자 닉네임', '작성자 프로필 사진', '지역명'(LIFE_TIP의 경우, null), '제목', '내용', '이미지 url', '스크랩 상태', '공감,댓글,조회수', '생성시간'을 제공합니다.
     
     - 쿼리파라미터 postId에 게시글 ID를 전달합니다.
     """

--- a/src/main/java/com/onenth/OneNth/domain/post/dto/PostDetailResponseDTO.java
+++ b/src/main/java/com/onenth/OneNth/domain/post/dto/PostDetailResponseDTO.java
@@ -12,6 +12,7 @@ public class PostDetailResponseDTO {
 
     private String postId;
     private String nickname;
+    private String profileImageUrl;
     private String regionName;
     private String title;
     private String content;

--- a/src/main/java/com/onenth/OneNth/domain/post/dto/PostListResponseDTO.java
+++ b/src/main/java/com/onenth/OneNth/domain/post/dto/PostListResponseDTO.java
@@ -3,6 +3,8 @@ package com.onenth.OneNth.domain.post.dto;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.util.List;
+
 @Getter
 @Builder
 public class PostListResponseDTO {
@@ -13,5 +15,6 @@ public class PostListResponseDTO {
     private int likeCount;         // 공감 수
     private int viewCount;         // 조회 수
     private boolean scrapStatus;   // 현재 로그인한 사용자의 스크랩 여부
+    private List<String> imageUrls;
     private String createdAt;
 }

--- a/src/main/java/com/onenth/OneNth/domain/post/service/PostQueryServiceImpl.java
+++ b/src/main/java/com/onenth/OneNth/domain/post/service/PostQueryServiceImpl.java
@@ -75,6 +75,7 @@ public class PostQueryServiceImpl implements PostQueryService {
 
     private PostListResponseDTO toPostListDTO(Post post, Long memberId) {
         boolean scrapStatus = ScrapRepository.existsByPostIdAndMemberId(post.getId(), memberId);
+        List<String> imageUrls = imageRepository.findUrlsByPost(post);
 
         return PostListResponseDTO.builder()
                 .postId(post.getId())
@@ -84,6 +85,7 @@ public class PostQueryServiceImpl implements PostQueryService {
                 .likeCount(post.getLike().size())
                 .viewCount(post.getViewCount())
                 .scrapStatus(scrapStatus)
+                .imageUrls(imageUrls)
                 .createdAt(post.getCreatedAt().toString())
                 .build();
     }
@@ -100,10 +102,12 @@ public class PostQueryServiceImpl implements PostQueryService {
         int likeCount = (int) LikeRepository.countByPost(post);
         boolean scrapStatus = ScrapRepository.existsByPostIdAndMemberId(postId, memberId);
         List<String> imageUrls = imageRepository.findUrlsByPost(post);
+        String profileImageUrl = post.getMember().getProfileImageUrl();
 
         return PostDetailResponseDTO.builder()
                 .postId(post.getId().toString())
                 .nickname(post.getMember().getNickname())
+                .profileImageUrl(profileImageUrl)
                 .regionName(post.getRegion() != null ? post.getRegion().getRegionName() : null)
                 .title(post.getTitle())
                 .content(post.getContent())


### PR DESCRIPTION
## 📌 작업 내용

> 게시글 조회 시 필요한 이미지 관련 응답을 추가했습니다.

> ### **1. 게시글 목록 조회**
> - 게시글 목록 조회 시, 응답으로 게시글 이미지 URL을 제공합니다.

>###  **2. 게시글 상세 조회**
> -  게시글 상세 조회 시, 응답으로 작성자의 프로필 이미지 URL을 제공합니다.

## ✨ 참고 사항


## 🧩 연관 이슈

> close #114 


<br>