### PR TITLE
✨[Feat] 내가 쓴 거래 글, 내가 스크랩한 거래 글 통합조회 API 구현

### DIFF
--- a/src/main/generated/com/onenth/OneNth/domain/product/entity/scrap/QPurchaseItemScrap.java
+++ b/src/main/generated/com/onenth/OneNth/domain/product/entity/scrap/QPurchaseItemScrap.java
@@ -22,13 +22,19 @@ public class QPurchaseItemScrap extends EntityPathBase<PurchaseItemScrap> {
 
     public static final QPurchaseItemScrap purchaseItemScrap = new QPurchaseItemScrap("purchaseItemScrap");
 
-    public final DateTimePath<java.time.LocalDateTime> createdAt = createDateTime("createdAt", java.time.LocalDateTime.class);
+    public final com.onenth.OneNth.domain.common.QBaseEntity _super = new com.onenth.OneNth.domain.common.QBaseEntity(this);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
 
     public final NumberPath<Long> id = createNumber("id", Long.class);
 
     public final com.onenth.OneNth.domain.member.entity.QMember member;
 
     public final com.onenth.OneNth.domain.product.entity.QPurchaseItem purchaseItem;
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> updatedAt = _super.updatedAt;
 
     public QPurchaseItemScrap(String variable) {
         this(PurchaseItemScrap.class, forVariable(variable), INITS);

--- a/src/main/generated/com/onenth/OneNth/domain/product/entity/scrap/QSharingItemScrap.java
+++ b/src/main/generated/com/onenth/OneNth/domain/product/entity/scrap/QSharingItemScrap.java
@@ -22,13 +22,19 @@ public class QSharingItemScrap extends EntityPathBase<SharingItemScrap> {
 
     public static final QSharingItemScrap sharingItemScrap = new QSharingItemScrap("sharingItemScrap");
 
-    public final DateTimePath<java.time.LocalDateTime> createdAt = createDateTime("createdAt", java.time.LocalDateTime.class);
+    public final com.onenth.OneNth.domain.common.QBaseEntity _super = new com.onenth.OneNth.domain.common.QBaseEntity(this);
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
 
     public final NumberPath<Long> id = createNumber("id", Long.class);
 
     public final com.onenth.OneNth.domain.member.entity.QMember member;
 
     public final com.onenth.OneNth.domain.product.entity.QSharingItem sharingItem;
+
+    //inherited
+    public final DateTimePath<java.time.LocalDateTime> updatedAt = _super.updatedAt;
 
     public QSharingItemScrap(String variable) {
         this(SharingItemScrap.class, forVariable(variable), INITS);

--- a/src/main/java/com/onenth/OneNth/domain/member/controller/MemberRestController.java
+++ b/src/main/java/com/onenth/OneNth/domain/member/controller/MemberRestController.java
@@ -260,4 +260,49 @@ public class MemberRestController {
         MemberResponseDTO.MemberProfilePreviewDTO response = memberQueryService.getMemberProfilePreview(memberId);
         return ApiResponse.onSuccess(response);
     }
+
+    /**
+     * 마이페이지 - 내가 작성한 같이사요/함께나눠요 통합 미리보기 조회 (최신순, 페이징)
+     */
+    @Operation(
+            summary = "마이페이지 - 내가 작성한 아이템(같이사요/함께나눠요) 통합 조회",
+            description = "사용자가 작성한 같이사요(PURCHASE)와 함께나눠요(SHARE)를 최신순으로 통합 조회합니다. 페이지 번호와 사이즈를 쿼리스트링으로 전달하세요."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "잘못된 요청입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+    })
+    @Parameters({
+            @Parameter(name = "page", description = "페이지 번호(1부터 시작)", example = "1", required = true),
+            @Parameter(name = "size", description = "페이지 당 미리보기 개수", example = "10", required = true)
+    })
+    @GetMapping("/mypage/items")
+    public ApiResponse<MemberResponseDTO.ItemPreviewListDTO> getMyItems(
+            @Parameter(hidden = true) @AuthUser Long memberId,
+            @RequestParam(name = "page", defaultValue = "1") Integer page,
+            @RequestParam(name = "size", defaultValue = "10") Integer size
+    ) {
+        return ApiResponse.onSuccess(memberQueryService.getMyAllItems(memberId, page, size));
+    }
+
+    @Operation(
+            summary = "마이페이지 - 내가 스크랩한 아이템(같이사요/함께나눠요) 통합 조회",
+            description = "사용자가 스크랩한 같이사요(PURCHASE)와 함께나눠요(SHARE)를 스크랩 시각 기준 최신순으로 통합 조회합니다. 페이지 번호와 사이즈를 쿼리스트링으로 전달하세요."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON400", description = "잘못된 요청입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+    })
+    @Parameters({
+            @Parameter(name = "page", description = "페이지 번호(1부터 시작)", example = "1", required = true),
+            @Parameter(name = "size", description = "페이지 당 미리보기 개수", example = "10", required = true)
+    })
+    @GetMapping("/mypage/scrapped-items")
+    public ApiResponse<MemberResponseDTO.ItemPreviewListDTO> getMyScrappedItems(
+            @Parameter(hidden = true) @AuthUser Long memberId,
+            @RequestParam(name = "page", defaultValue = "1") Integer page,
+            @RequestParam(name = "size", defaultValue = "10") Integer size
+    ) {
+        return ApiResponse.onSuccess(memberQueryService.getMyScrappedItems(memberId, page, size));
+    }
 }

--- a/src/main/java/com/onenth/OneNth/domain/member/converter/MemberConverter.java
+++ b/src/main/java/com/onenth/OneNth/domain/member/converter/MemberConverter.java
@@ -209,11 +209,11 @@ public class MemberConverter {
     public static MemberResponseDTO.ItemPreviewDTO fromPurchase(PurchaseItem pi) {
         return MemberResponseDTO.ItemPreviewDTO.builder()
                 .itemId(pi.getId())
-                .itemType("PURCHASE") // or "같이사요"
+                .itemType("같이 사요")
                 .productName(pi.getProductName()) // = name
                 .price(pi.getPrice())
-                .quantity(null)                   // Purchase에는 별도 수량 필드 없음
-                .originalPrice(pi.getPrice())     // 정의에 따라: 원가가 이 값이면 그대로, 아니면 null
+                .quantity(1)                // Purchase에는 별도 수량 필드 없음
+                .originalPrice(pi.getPrice())     // 정의에 따라
                 .createdTime(formatRelativeTime(pi.getCreatedAt()))
                 .createdAt(pi.getCreatedAt())
                 .build();
@@ -222,11 +222,11 @@ public class MemberConverter {
     public static MemberResponseDTO.ItemPreviewDTO fromSharing(SharingItem si) {
         return MemberResponseDTO.ItemPreviewDTO.builder()
                 .itemId(si.getId())
-                .itemType("SHARE") // or "함께나눠요"
+                .itemType("함께 나눠요") // or "함께나눠요"
                 .productName(si.getProductName()) // = title
                 .price(si.getPrice())
                 .quantity(si.getQuantity())       // Sharing에는 수량 존재
-                .originalPrice(null)              // 정의되면 세팅, 없으면 null
+                .originalPrice(si.getPrice())   // 정의에 따라 세팅
                 .createdTime(formatRelativeTime(si.getCreatedAt()))
                 .createdAt(si.getCreatedAt())
                 .build();
@@ -237,11 +237,11 @@ public class MemberConverter {
         PurchaseItem pi = scrap.getPurchaseItem();
         return MemberResponseDTO.ItemPreviewDTO.builder()
                 .itemId(pi.getId())
-                .itemType("PURCHASE")
+                .itemType("같이 사요")
                 .productName(pi.getProductName())
                 .price(pi.getPrice())
-                .quantity(null)
-                .originalPrice(null) // 정의에 따라 세팅
+                .quantity(1)
+                .originalPrice(pi.getPrice()) // 정의에 따라 세팅
                 .createdTime(formatRelativeTime(pi.getCreatedAt()))
                 .createdAt(pi.getCreatedAt())
                 .scrappedAt(scrap.getCreatedAt())
@@ -252,11 +252,11 @@ public class MemberConverter {
         SharingItem si = scrap.getSharingItem();
         return MemberResponseDTO.ItemPreviewDTO.builder()
                 .itemId(si.getId())
-                .itemType("SHARE")
+                .itemType("함께 나눠요")
                 .productName(si.getProductName())
                 .price(si.getPrice())
                 .quantity(si.getQuantity())
-                .originalPrice(null) // 정의에 따라 세팅
+                .originalPrice(si.getPrice()) // 정의에 따라 세팅
                 .createdTime(formatRelativeTime(si.getCreatedAt()))
                 .createdAt(si.getCreatedAt())
                 .scrappedAt(scrap.getCreatedAt())

--- a/src/main/java/com/onenth/OneNth/domain/member/converter/MemberConverter.java
+++ b/src/main/java/com/onenth/OneNth/domain/member/converter/MemberConverter.java
@@ -10,6 +10,10 @@ import com.onenth.OneNth.domain.member.entity.enums.MemberStatus;
 import com.onenth.OneNth.domain.post.entity.Like;
 import com.onenth.OneNth.domain.post.entity.Post;
 import com.onenth.OneNth.domain.post.entity.Scrap;
+import com.onenth.OneNth.domain.product.entity.PurchaseItem;
+import com.onenth.OneNth.domain.product.entity.SharingItem;
+import com.onenth.OneNth.domain.product.entity.scrap.PurchaseItemScrap;
+import com.onenth.OneNth.domain.product.entity.scrap.SharingItemScrap;
 import com.onenth.OneNth.domain.region.entity.Region;
 import org.springframework.data.domain.Page;
 
@@ -199,6 +203,63 @@ public class MemberConverter {
                 .likeCount(myPost.getLike().size())
                 .viewCount(0)
                 .createdTime(formatRelativeTime(myPost.getCreatedAt()))
+                .build();
+    }
+
+    public static MemberResponseDTO.ItemPreviewDTO fromPurchase(PurchaseItem pi) {
+        return MemberResponseDTO.ItemPreviewDTO.builder()
+                .itemId(pi.getId())
+                .itemType("PURCHASE") // or "같이사요"
+                .productName(pi.getProductName()) // = name
+                .price(pi.getPrice())
+                .quantity(null)                   // Purchase에는 별도 수량 필드 없음
+                .originalPrice(pi.getPrice())     // 정의에 따라: 원가가 이 값이면 그대로, 아니면 null
+                .createdTime(formatRelativeTime(pi.getCreatedAt()))
+                .createdAt(pi.getCreatedAt())
+                .build();
+    }
+
+    public static MemberResponseDTO.ItemPreviewDTO fromSharing(SharingItem si) {
+        return MemberResponseDTO.ItemPreviewDTO.builder()
+                .itemId(si.getId())
+                .itemType("SHARE") // or "함께나눠요"
+                .productName(si.getProductName()) // = title
+                .price(si.getPrice())
+                .quantity(si.getQuantity())       // Sharing에는 수량 존재
+                .originalPrice(null)              // 정의되면 세팅, 없으면 null
+                .createdTime(formatRelativeTime(si.getCreatedAt()))
+                .createdAt(si.getCreatedAt())
+                .build();
+    }
+
+
+    public static MemberResponseDTO.ItemPreviewDTO fromPurchaseScrap(PurchaseItemScrap scrap) {
+        PurchaseItem pi = scrap.getPurchaseItem();
+        return MemberResponseDTO.ItemPreviewDTO.builder()
+                .itemId(pi.getId())
+                .itemType("PURCHASE")
+                .productName(pi.getProductName())
+                .price(pi.getPrice())
+                .quantity(null)
+                .originalPrice(null) // 정의에 따라 세팅
+                .createdTime(formatRelativeTime(pi.getCreatedAt()))
+                .createdAt(pi.getCreatedAt())
+                .scrappedAt(scrap.getCreatedAt())
+                .build();
+    }
+
+    public static MemberResponseDTO.ItemPreviewDTO fromSharingScrap(SharingItemScrap scrap) {
+        SharingItem si = scrap.getSharingItem();
+        return MemberResponseDTO.ItemPreviewDTO.builder()
+                .itemId(si.getId())
+                .itemType("SHARE")
+                .productName(si.getProductName())
+                .price(si.getPrice())
+                .quantity(si.getQuantity())
+                .originalPrice(null) // 정의에 따라 세팅
+                .createdTime(formatRelativeTime(si.getCreatedAt()))
+                .createdAt(si.getCreatedAt())
+                .scrappedAt(scrap.getCreatedAt())
                 .build();
     }
 }

--- a/src/main/java/com/onenth/OneNth/domain/member/dto/MemberResponseDTO.java
+++ b/src/main/java/com/onenth/OneNth/domain/member/dto/MemberResponseDTO.java
@@ -1,5 +1,6 @@
 package com.onenth.OneNth.domain.member.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -117,6 +118,39 @@ public class MemberResponseDTO {
     @AllArgsConstructor
     public static class TokenReissueResultDTO {
         String accessToken;
+    }
+
+    // 미리보기 하나
+    @Getter
+    @Builder
+    @AllArgsConstructor @NoArgsConstructor
+    public static class ItemPreviewDTO {
+        private Long itemId;             // 공통 ID
+        private String itemType;         // "PURCHASE" | "SHARE" (또는 "같이사요" | "함께나눠요")
+        private String productName;      // Purchase: name / Sharing: title
+        private Integer price;           // 현재 노출 가격 (필수)
+        private Integer quantity;        // SharingItem만 값 존재 (없으면 null)
+        private Integer originalPrice;   // PurchaseItem의 원래 구매가 등 (없으면 null)
+        private String createdTime;      // 상대시간 문자열
+        @JsonIgnore
+        private LocalDateTime createdAt; // 정렬용(응답에 노출X)
+        @JsonIgnore
+        private LocalDateTime scrappedAt; // 스크랩 시각(정렬용)
+    }
+
+    // 목록 + 페이지 정보
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class ItemPreviewListDTO {
+        private List<ItemPreviewDTO> items;
+
+        private Integer page;       // 1-base
+        private Integer size;
+        private Long totalCount;    // 대략 합계(정확 합계 원하면 둘 다 count 쿼리)
+        private Boolean hasNext;
+
     }
 
 }

--- a/src/main/java/com/onenth/OneNth/domain/member/service/memberService/MemberQueryService.java
+++ b/src/main/java/com/onenth/OneNth/domain/member/service/memberService/MemberQueryService.java
@@ -14,4 +14,10 @@ public interface MemberQueryService {
 
     // ID 기반 사용자 프로필 정보 조회
     MemberResponseDTO.MemberProfilePreviewDTO getMemberProfilePreview(Long memberId);
+
+    // 사용자가 쓴 거래글 조회
+    MemberResponseDTO.ItemPreviewListDTO getMyAllItems(Long memberId, Integer page, Integer size);
+
+    // 사용자가 스크랩한 거래글 조회
+    MemberResponseDTO.ItemPreviewListDTO getMyScrappedItems(Long memberId, Integer page, Integer size);
 }

--- a/src/main/java/com/onenth/OneNth/domain/member/service/memberService/MemberQueryServiceImpl.java
+++ b/src/main/java/com/onenth/OneNth/domain/member/service/memberService/MemberQueryServiceImpl.java
@@ -10,6 +10,14 @@ import com.onenth.OneNth.domain.post.entity.Scrap;
 import com.onenth.OneNth.domain.post.repository.likeRepository.LikeRepository;
 import com.onenth.OneNth.domain.post.repository.PostRepository;
 import com.onenth.OneNth.domain.post.repository.scrapRepository.ScrapRepository;
+import com.onenth.OneNth.domain.product.entity.PurchaseItem;
+import com.onenth.OneNth.domain.product.entity.SharingItem;
+import com.onenth.OneNth.domain.product.entity.scrap.PurchaseItemScrap;
+import com.onenth.OneNth.domain.product.entity.scrap.SharingItemScrap;
+import com.onenth.OneNth.domain.product.repository.itemRepository.purchase.PurchaseItemRepository;
+import com.onenth.OneNth.domain.product.repository.itemRepository.sharing.SharingItemRepository;
+import com.onenth.OneNth.domain.product.repository.scrapRepository.PurchaseItemScrapRepository;
+import com.onenth.OneNth.domain.product.repository.scrapRepository.SharingItemScrapRepository;
 import com.onenth.OneNth.global.apiPayload.code.status.ErrorStatus;
 import com.onenth.OneNth.global.apiPayload.exception.handler.MemberHandler;
 import lombok.RequiredArgsConstructor;
@@ -18,6 +26,12 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @Transactional(readOnly = true)
@@ -28,6 +42,11 @@ public class MemberQueryServiceImpl implements MemberQueryService {
     private final ScrapRepository scrapRepository;
     private final LikeRepository likeRepository;
     private final PostRepository postRepository;
+    private final PurchaseItemRepository purchaseItemRepository;
+    private final SharingItemRepository sharingItemRepository;
+    private final SharingItemScrapRepository sharingItemScrapRepository;
+    private final PurchaseItemScrapRepository purchaseItemScrapRepository;
+
 
     @Override
     public MemberResponseDTO.PostListDTO getScrappedPosts(Long memberId, Integer page, Integer size) {
@@ -78,5 +97,100 @@ public class MemberQueryServiceImpl implements MemberQueryService {
         Member member =  memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
         return new MemberResponseDTO.MemberProfilePreviewDTO(member.getId(), member.getName(), member.getProfileImageUrl());
+    }
+
+    public MemberResponseDTO.ItemPreviewListDTO getMyAllItems(Long memberId, Integer page, Integer size) {
+        if (memberId == null) {
+            return MemberResponseDTO.ItemPreviewListDTO.builder()
+                    .items(Collections.emptyList())
+                    .page(1).size(size == null ? 10 : size)
+                    .totalCount(0L).hasNext(false)
+                    .build();
+        }
+
+        int pg = (page == null || page < 1) ? 1 : page;
+        int sz = (size == null || size < 1) ? 10 : size;
+        PageRequest pageable = PageRequest.of(pg - 1, sz, Sort.by(Sort.Direction.DESC, "createdAt"));
+
+        // 핵심: 두 타입을 각각 가져와서 DTO 변환 → 합치고 createdAt desc로 정렬 → page 사이즈만큼 잘라서 반환
+        Page<PurchaseItem> piPage = purchaseItemRepository.findByMemberId(memberId, pageable);
+        Page<SharingItem>  siPage = sharingItemRepository.findByMemberId(memberId, pageable);
+
+        List<MemberResponseDTO.ItemPreviewDTO> merged = new ArrayList<>(sz * 2);
+
+        for (PurchaseItem p : piPage.getContent()) {
+            merged.add(MemberConverter.fromPurchase(p));
+        }
+        for (SharingItem s : siPage.getContent()) {
+            merged.add(MemberConverter.fromSharing(s));
+        }
+
+        // 병합 후 정렬 (createdAt desc)
+        merged.sort(Comparator.comparing(MemberResponseDTO.ItemPreviewDTO::getCreatedAt).reversed());
+
+        // 현재 페이지 크기만큼 자르기 (두 페이지를 각각 size만큼만 가져왔기 때문에 충분치 않을 수 있음)
+        // 안정적으로 하려면 각 repo에서 더 넉넉히 끌어오거나 keyset 방식을 써도 됩니다.
+        List<MemberResponseDTO.ItemPreviewDTO> pageSlice = merged.stream()
+                .limit(sz)
+                .collect(Collectors.toList());
+
+        // 총합(대략)과 다음 페이지 여부 계산
+        long total = purchaseItemRepository.countByMemberId(memberId)
+                + sharingItemRepository.countByMemberId(memberId);
+
+        boolean hasNext = (long) (pg * sz) < total;
+
+        return MemberResponseDTO.ItemPreviewListDTO.builder()
+                .items(pageSlice)
+                .page(pg)
+                .size(sz)
+                .totalCount(total)
+                .hasNext(hasNext)
+                .build();
+    }
+
+    public MemberResponseDTO.ItemPreviewListDTO getMyScrappedItems(Long memberId, Integer page, Integer size) {
+        if (memberId == null) {
+            return MemberResponseDTO.ItemPreviewListDTO.builder()
+                    .items(Collections.emptyList())
+                    .page(1)
+                    .size(size == null ? 10 : size)
+                    .totalCount(0L)
+                    .hasNext(false)
+                    .build();
+        }
+
+        int pg = (page == null || page < 1) ? 1 : page;
+        int sz = (size == null || size < 1) ? 10 : size;
+
+        // 스크랩 기준 최신순
+        PageRequest pageable = PageRequest.of(pg - 1, sz, Sort.by(Sort.Direction.DESC, "createdAt"));
+
+        Page<PurchaseItemScrap> pis = purchaseItemScrapRepository.findByMemberId(memberId, pageable);
+        Page<SharingItemScrap>  sis = sharingItemScrapRepository.findByMemberId(memberId, pageable);
+
+        List<MemberResponseDTO.ItemPreviewDTO> merged = new ArrayList<>(sz * 2);
+
+        for (PurchaseItemScrap s : pis.getContent()) merged.add(MemberConverter.fromPurchaseScrap(s));
+        for (SharingItemScrap  s : sis.getContent()) merged.add(MemberConverter.fromSharingScrap(s));
+
+        // 스크랩 시각 기준 최신순으로 병합 정렬
+        merged.sort(Comparator.comparing(MemberResponseDTO.ItemPreviewDTO::getScrappedAt, Comparator.nullsLast(Comparator.naturalOrder())).reversed());
+
+        // 현재 페이지 사이즈만큼 자르기
+        List<MemberResponseDTO.ItemPreviewDTO> pageSlice = merged.stream().limit(sz).toList();
+
+        long total = purchaseItemScrapRepository.countByMemberId(memberId)
+                + sharingItemScrapRepository.countByMemberId(memberId);
+
+        boolean hasNext = (long) (pg * sz) < total;
+
+        return MemberResponseDTO.ItemPreviewListDTO.builder()
+                .items(pageSlice)
+                .page(pg)
+                .size(sz)
+                .totalCount(total)
+                .hasNext(hasNext)
+                .build();
     }
 }

--- a/src/main/java/com/onenth/OneNth/domain/product/entity/scrap/PurchaseItemScrap.java
+++ b/src/main/java/com/onenth/OneNth/domain/product/entity/scrap/PurchaseItemScrap.java
@@ -1,5 +1,6 @@
 package com.onenth.OneNth.domain.product.entity.scrap;
 
+import com.onenth.OneNth.domain.common.BaseEntity;
 import com.onenth.OneNth.domain.product.entity.PurchaseItem;
 import jakarta.persistence.*;
 
@@ -15,7 +16,7 @@ import lombok.*;
 @AllArgsConstructor
 @Builder
 @Table(name = "purchase_item_scrap")
-public class PurchaseItemScrap {
+public class PurchaseItemScrap extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -29,11 +30,11 @@ public class PurchaseItemScrap {
     @JoinColumn(name = "purchase_item_id", nullable = false)
     private PurchaseItem purchaseItem;
 
-    private LocalDateTime createdAt;
-
-    @PrePersist
-    public void onCreate() {
-        this.createdAt = LocalDateTime.now();
-    }
+//    private LocalDateTime createdAt;
+//
+//    @PrePersist
+//    public void onCreate() {
+//        this.createdAt = LocalDateTime.now();
+//    }
 }
 

--- a/src/main/java/com/onenth/OneNth/domain/product/entity/scrap/SharingItemScrap.java
+++ b/src/main/java/com/onenth/OneNth/domain/product/entity/scrap/SharingItemScrap.java
@@ -1,5 +1,6 @@
 package com.onenth.OneNth.domain.product.entity.scrap;
 
+import com.onenth.OneNth.domain.common.BaseEntity;
 import com.onenth.OneNth.domain.product.entity.SharingItem;
 import jakarta.persistence.*;
 
@@ -15,7 +16,7 @@ import lombok.*;
 @AllArgsConstructor
 @Builder
 @Table(name = "sharing_item_scrap")
-public class SharingItemScrap {
+public class SharingItemScrap extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -29,5 +30,5 @@ public class SharingItemScrap {
     @JoinColumn(name = "sharing_item_id", nullable = false)
     private SharingItem sharingItem;
 
-    private LocalDateTime createdAt;
+//    private LocalDateTime createdAt;
 }

--- a/src/main/java/com/onenth/OneNth/domain/product/repository/itemRepository/purchase/PurchaseItemRepository.java
+++ b/src/main/java/com/onenth/OneNth/domain/product/repository/itemRepository/purchase/PurchaseItemRepository.java
@@ -5,6 +5,8 @@ import com.onenth.OneNth.domain.product.entity.PurchaseItem;
 import com.onenth.OneNth.domain.product.entity.enums.PurchaseMethod;
 import com.onenth.OneNth.domain.product.entity.enums.Status;
 import com.onenth.OneNth.domain.region.entity.Region;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -32,4 +34,14 @@ public interface PurchaseItemRepository  extends JpaRepository<PurchaseItem, Lon
 
     @EntityGraph(attributePaths = {"itemImages"})
     Optional<PurchaseItem> findWithItemImagesById(Long id);
+
+    @Query("""
+        select p from PurchaseItem p
+        where p.member.id = :memberId
+        order by p.createdAt desc
+    """)
+    Page<PurchaseItem> findByMemberId(@Param("memberId") Long memberId, Pageable pageable);
+
+    @Query("select count(p) from PurchaseItem p where p.member.id = :memberId")
+    long countByMemberId(@Param("memberId") Long memberId);
 }

--- a/src/main/java/com/onenth/OneNth/domain/product/repository/itemRepository/sharing/SharingItemRepository.java
+++ b/src/main/java/com/onenth/OneNth/domain/product/repository/itemRepository/sharing/SharingItemRepository.java
@@ -6,6 +6,8 @@ import com.onenth.OneNth.domain.product.entity.SharingItem;
 import com.onenth.OneNth.domain.product.entity.enums.PurchaseMethod;
 import com.onenth.OneNth.domain.region.entity.Region;
 import com.onenth.OneNth.domain.product.entity.enums.Status;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -48,4 +50,14 @@ public interface SharingItemRepository extends JpaRepository<SharingItem, Long>,
 
     @EntityGraph(attributePaths = {"itemImages"})
     Optional<SharingItem> findWithItemImagesById(Long id);
+
+    @Query("""
+        select s from SharingItem s
+        where s.member.id = :memberId
+        order by s.createdAt desc
+    """)
+    Page<SharingItem> findByMemberId(@Param("memberId") Long memberId, Pageable pageable);
+
+    @Query("select count(s) from SharingItem s where s.member.id = :memberId")
+    long countByMemberId(@Param("memberId") Long memberId);
 }

--- a/src/main/java/com/onenth/OneNth/domain/product/repository/scrapRepository/PurchaseItemScrapRepository.java
+++ b/src/main/java/com/onenth/OneNth/domain/product/repository/scrapRepository/PurchaseItemScrapRepository.java
@@ -3,6 +3,8 @@ package com.onenth.OneNth.domain.product.repository.scrapRepository;
 import com.onenth.OneNth.domain.member.entity.Member;
 import com.onenth.OneNth.domain.product.entity.PurchaseItem;
 import com.onenth.OneNth.domain.product.entity.scrap.PurchaseItemScrap;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -20,4 +22,15 @@ public interface PurchaseItemScrapRepository extends JpaRepository<PurchaseItemS
 
     // DELETE
     Optional<PurchaseItemScrap> findByMemberIdAndPurchaseItemId(Long memberId, Long purchaseItemId);
+
+    @Query("""
+       select s from PurchaseItemScrap s
+       join fetch s.purchaseItem pi
+       where s.member.id = :memberId
+       order by s.createdAt desc
+    """)
+    Page<PurchaseItemScrap> findByMemberId(@Param("memberId") Long memberId, Pageable pageable);
+
+    @Query("select count(s) from PurchaseItemScrap s where s.member.id = :memberId")
+    long countByMemberId(@Param("memberId") Long memberId);
 }

--- a/src/main/java/com/onenth/OneNth/domain/product/repository/scrapRepository/SharingItemScrapRepository.java
+++ b/src/main/java/com/onenth/OneNth/domain/product/repository/scrapRepository/SharingItemScrapRepository.java
@@ -3,8 +3,11 @@ package com.onenth.OneNth.domain.product.repository.scrapRepository;
 import com.onenth.OneNth.domain.member.entity.Member;
 import com.onenth.OneNth.domain.product.entity.SharingItem;
 import com.onenth.OneNth.domain.product.entity.scrap.SharingItemScrap;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -18,4 +21,15 @@ public interface SharingItemScrapRepository extends JpaRepository<SharingItemScr
     List<SharingItemScrap> findByUserId(Long userId);
 
     Optional<SharingItemScrap> findByMemberIdAndSharingItemId(Long userId, Long itemId);
+
+    @Query("""
+       select s from SharingItemScrap s
+       join fetch s.sharingItem si
+       where s.member.id = :memberId
+       order by s.createdAt desc
+    """)
+    Page<SharingItemScrap> findByMemberId(@Param("memberId") Long memberId, Pageable pageable);
+
+    @Query("select count(s) from SharingItemScrap s where s.member.id = :memberId")
+    long countByMemberId(@Param("memberId") Long memberId);
 }


### PR DESCRIPTION
## 📌 작업 내용

> ### 1. 내가 쓴 거래 글 통합조회 API 구현
> - 같이 사요, 함께 나눠요 Entity를 각각 페이징으로 조회하여 등록 순서 대로 보여줍니다.
> - figma에는 모두 가격/수량/원래 가격 을 표시하는 걸로 나오는데 entity에 원래 가격 값이 따로 없어서 가격, 원래 가격을 모두 price로 처리했습니다.
> - 수량(quantity)는 sharingItem에만 있어서 purchaseItem은 수량을 1로 처리합니다.

> ### 2. 내가 스크랩한 거래 글 통합조회 API 구현
> - 같이 사요, 함께 나눠요 Entity를 각각 페이징으로 조회하여 스크랩된 순서 대로 보여줍니다.
> - figma에는 모두 가격/수량/원래 가격 을 표시하는 걸로 나오는데 entity에 원래 가격 값이 따로 없어서 가격, 원래 가격을 모두 price로 처리했습니다.
> - 수량(quantity)는 sharingItem에만 있어서 purchaseItem은 수량을 1로 처리합니다.
## ✨ 참고 사항

> 가격/수량/원래 가격에 대해 다르게 처리해야한다면 리뷰 남겨주세요

## 🧩 연관 이슈

> close #120 


<br>