### PR TITLE
✨[Feat] 게시물 댓글 알림 on/off 설정 API 추가

### DIFF
--- a/src/main/generated/com/onenth/OneNth/domain/member/entity/QMemberAlertSetting.java
+++ b/src/main/generated/com/onenth/OneNth/domain/member/entity/QMemberAlertSetting.java
@@ -26,6 +26,8 @@ public class QMemberAlertSetting extends EntityPathBase<MemberAlertSetting> {
 
     public final BooleanPath chatAlerts = createBoolean("chatAlerts");
 
+    public final BooleanPath commentAlerts = createBoolean("commentAlerts");
+
     //inherited
     public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
 

--- a/src/main/java/com/onenth/OneNth/domain/alert/entity/AlertType.java
+++ b/src/main/java/com/onenth/OneNth/domain/alert/entity/AlertType.java
@@ -6,6 +6,7 @@ public enum AlertType {
     DISCOUNT, // 할인 정보
     RESTAURANT, // 우리동네 맛집, 카페
     LIFE_TIP, // 생활 정보
+    COMMENT,
 
     CHAT
 }

--- a/src/main/java/com/onenth/OneNth/domain/member/entity/MemberAlertSetting.java
+++ b/src/main/java/com/onenth/OneNth/domain/member/entity/MemberAlertSetting.java
@@ -25,6 +25,9 @@ public class MemberAlertSetting extends BaseEntity {
     @Column(nullable = false)
     private boolean scrapAlerts = false; // 스크랩알림 수신여부
 
+    @Column(nullable = false)
+    private boolean commentAlerts = false; // 게시물 댓글 알림 수신여부
+
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private Member member;
@@ -33,6 +36,7 @@ public class MemberAlertSetting extends BaseEntity {
         switch (alertType) {
             case CHAT -> chatAlerts = true;
             case REVIEW -> reviewAlerts = true;
+            case COMMENT -> commentAlerts = true;
 /*            case SCRAP -> scrapAlerts = true;*/
         }
     }
@@ -41,6 +45,7 @@ public class MemberAlertSetting extends BaseEntity {
         switch (alertType) {
             case CHAT -> chatAlerts = false;
             case REVIEW -> reviewAlerts = false;
+            case COMMENT -> commentAlerts = false;
 /*            case SCRAP -> scrapAlerts = false;*/
         }
     }

--- a/src/main/java/com/onenth/OneNth/domain/member/service/memberService/MemberCommandServiceImpl.java
+++ b/src/main/java/com/onenth/OneNth/domain/member/service/memberService/MemberCommandServiceImpl.java
@@ -80,6 +80,7 @@ public class MemberCommandServiceImpl implements MemberCommandService {
                 .chatAlerts(true)
                 .scrapAlerts(true)
                 .reviewAlerts(true)
+                .commentAlerts(true)
                 .build();
         memberAlertSettingRepository.save(alertSetting);
 

--- a/src/main/java/com/onenth/OneNth/domain/member/settings/alert/generalAlert/controller/GeneralAlertController.java
+++ b/src/main/java/com/onenth/OneNth/domain/member/settings/alert/generalAlert/controller/GeneralAlertController.java
@@ -81,6 +81,24 @@ public class GeneralAlertController {
     }
 
     @Operation(
+            summary =  "게시글 댓글 알림 on/off API",
+            description = "사용자 설정 중 게시글 댓글 알림 설정 on/off API입니다. 응답으로 alertType(COMMENT)과 enabled(활성 여부)을 반환합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 댓글 알람 설정 변경 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "MEMBER001", description = "존재하지 않는 사용자입니다.", content = @Content(schema = @Schema(implementation = ErrorReasonDTO.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "ALERT_SETTING001", description = "해당 사용자의 알림 설정 정보가 존재하지 않습니다.", content = @Content(schema = @Schema(implementation = ErrorReasonDTO.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON500", description = "서버 에러, 관리자에게 문의 바랍니다", content = @Content(schema = @Schema(implementation = ErrorReasonDTO.class))),
+    })
+    @PostMapping("/comment-alerts")
+    public ApiResponse<GeneralAlertResponseDTO.SetCommentAlertStatusResponseDTO> setCommentAlertStatus(
+            @Parameter(hidden=true) @AuthUser Long userId,
+            @Valid @RequestBody GeneralAlertRequestDTO.SetCommentAlertStatusRequestDTO request
+    ) {
+        return ApiResponse.onSuccess(generalAlertCommandService.setCommentAlertStatus(userId, request));
+    }
+
+    @Operation(
             summary =  "알림 설정 전체 조회 API",
             description = "사용자 설정 중 모든 알림 설정을 조회하는 API입니다. 응답으로 스크랩 알림 활성화 여부, 리뷰 알림 활성화 여부, 키워드 알림 목록 및 활성화 여부를 포함한 리스트을 반환합니다. " +
                     "이때 키워드 알림 목록은 키워드 타입(region/product)에 관계없이 가장 최근에 등록한 알림이 먼저 표시됩니다."

--- a/src/main/java/com/onenth/OneNth/domain/member/settings/alert/generalAlert/converter/GeneralAlertConverter.java
+++ b/src/main/java/com/onenth/OneNth/domain/member/settings/alert/generalAlert/converter/GeneralAlertConverter.java
@@ -34,6 +34,13 @@ public class GeneralAlertConverter {
                 .build();
     }
 
+    public static GeneralAlertResponseDTO.SetCommentAlertStatusResponseDTO toSetCommentAlertStatusResponseDTO(MemberAlertSetting memberAlertSetting) {
+        return GeneralAlertResponseDTO.SetCommentAlertStatusResponseDTO.builder()
+                .alertType(AlertType.COMMENT)
+                .enabled(memberAlertSetting.isCommentAlerts())
+                .build();
+    }
+
     public static GeneralAlertResponseDTO.GetAllAlertSettingsResponseDTO toGetAllAlertSettingsResponseDTO(
             GeneralAlertResponseDTO.GeneralAlertSummary reviewAlertSummary,
             List<GeneralAlertResponseDTO.KeywordAlertSummary> keywordAlertSummaryList

--- a/src/main/java/com/onenth/OneNth/domain/member/settings/alert/generalAlert/converter/GeneralAlertConverter.java
+++ b/src/main/java/com/onenth/OneNth/domain/member/settings/alert/generalAlert/converter/GeneralAlertConverter.java
@@ -43,10 +43,12 @@ public class GeneralAlertConverter {
 
     public static GeneralAlertResponseDTO.GetAllAlertSettingsResponseDTO toGetAllAlertSettingsResponseDTO(
             GeneralAlertResponseDTO.GeneralAlertSummary reviewAlertSummary,
+            GeneralAlertResponseDTO.GeneralAlertSummary commentAlertSummary,
             List<GeneralAlertResponseDTO.KeywordAlertSummary> keywordAlertSummaryList
     ) {
         return GeneralAlertResponseDTO.GetAllAlertSettingsResponseDTO.builder()
                 .reviewAlertSummary(reviewAlertSummary)
+                .commentAlertSummary(commentAlertSummary)
                 .keywordAlertSummaryList(keywordAlertSummaryList)
                 .build();
     }
@@ -64,6 +66,11 @@ public class GeneralAlertConverter {
             return GeneralAlertResponseDTO.GeneralAlertSummary.builder()
                     .alertType(alertType)
                     .enabled(memberAlertSetting.isReviewAlerts())
+                    .build();
+        } else if (alertType == AlertType.COMMENT) {
+            return GeneralAlertResponseDTO.GeneralAlertSummary.builder()
+                    .alertType(alertType)
+                    .enabled(memberAlertSetting.isCommentAlerts())
                     .build();
         } else {
             throw new GeneralException(ErrorStatus.UNEXPECTED_ALERT_TYPE);

--- a/src/main/java/com/onenth/OneNth/domain/member/settings/alert/generalAlert/dto/GeneralAlertRequestDTO.java
+++ b/src/main/java/com/onenth/OneNth/domain/member/settings/alert/generalAlert/dto/GeneralAlertRequestDTO.java
@@ -36,4 +36,14 @@ public class GeneralAlertRequestDTO {
         private Boolean isEnabled;
 
     }
+
+    @Getter
+    @NoArgsConstructor
+    public static class SetCommentAlertStatusRequestDTO {
+
+        @Schema(description = "댓글 알림 전체 활성화 여부", example = "true")
+        @NotNull(message = "알림 활성화 여부는 필수입니다.")
+        private Boolean isEnabled;
+
+    }
 }

--- a/src/main/java/com/onenth/OneNth/domain/member/settings/alert/generalAlert/dto/GeneralAlertResponseDTO.java
+++ b/src/main/java/com/onenth/OneNth/domain/member/settings/alert/generalAlert/dto/GeneralAlertResponseDTO.java
@@ -42,6 +42,15 @@ public class GeneralAlertResponseDTO {
     @Builder
     @AllArgsConstructor
     @NoArgsConstructor
+    public static class SetCommentAlertStatusResponseDTO {
+        AlertType alertType;
+        boolean enabled;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
     public static class GetAllAlertSettingsResponseDTO {
         GeneralAlertSummary reviewAlertSummary;
         List<KeywordAlertSummary> keywordAlertSummaryList;

--- a/src/main/java/com/onenth/OneNth/domain/member/settings/alert/generalAlert/dto/GeneralAlertResponseDTO.java
+++ b/src/main/java/com/onenth/OneNth/domain/member/settings/alert/generalAlert/dto/GeneralAlertResponseDTO.java
@@ -53,6 +53,7 @@ public class GeneralAlertResponseDTO {
     @NoArgsConstructor
     public static class GetAllAlertSettingsResponseDTO {
         GeneralAlertSummary reviewAlertSummary;
+        GeneralAlertSummary commentAlertSummary;
         List<KeywordAlertSummary> keywordAlertSummaryList;
     }
 

--- a/src/main/java/com/onenth/OneNth/domain/member/settings/alert/generalAlert/service/GeneralAlertCommandService.java
+++ b/src/main/java/com/onenth/OneNth/domain/member/settings/alert/generalAlert/service/GeneralAlertCommandService.java
@@ -20,4 +20,9 @@ public interface GeneralAlertCommandService {
             GeneralAlertRequestDTO.SetChatAlertStatusRequestDTO request
     );
 
+    GeneralAlertResponseDTO.SetCommentAlertStatusResponseDTO setCommentAlertStatus(
+            Long userId,
+            GeneralAlertRequestDTO.SetCommentAlertStatusRequestDTO request
+    );
+
 }

--- a/src/main/java/com/onenth/OneNth/domain/member/settings/alert/generalAlert/service/GeneralAlertCommandServiceImpl.java
+++ b/src/main/java/com/onenth/OneNth/domain/member/settings/alert/generalAlert/service/GeneralAlertCommandServiceImpl.java
@@ -84,4 +84,24 @@ public class GeneralAlertCommandServiceImpl implements GeneralAlertCommandServic
 
         return GeneralAlertConverter.toSetChatAlertStatusResponseDTO(memberAlertSetting);
     }
+
+    @Override
+    public GeneralAlertResponseDTO.SetCommentAlertStatusResponseDTO setCommentAlertStatus(
+            Long userId,
+            GeneralAlertRequestDTO.SetCommentAlertStatusRequestDTO request
+    ) {
+        Member member = memberRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+
+        MemberAlertSetting memberAlertSetting = memberAlertSettingRepository.findByMember(member)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.ALERT_SETTING_NOT_FOUND));
+
+        if (request.getIsEnabled()) {
+            memberAlertSetting.enableAlerts(AlertType.COMMENT);
+        } else {
+            memberAlertSetting.disableAlerts(AlertType.COMMENT);
+        }
+
+        return GeneralAlertConverter.toSetCommentAlertStatusResponseDTO(memberAlertSetting);
+    }
 }

--- a/src/main/java/com/onenth/OneNth/domain/member/settings/alert/generalAlert/service/GeneralAlertQueryServiceImpl.java
+++ b/src/main/java/com/onenth/OneNth/domain/member/settings/alert/generalAlert/service/GeneralAlertQueryServiceImpl.java
@@ -11,7 +11,6 @@ import com.onenth.OneNth.domain.member.settings.alert.generalAlert.dto.GeneralAl
 import com.onenth.OneNth.domain.member.settings.alert.generalAlert.repository.MemberAlertSettingRepository;
 import com.onenth.OneNth.domain.member.settings.alert.keywordAlert.repository.ProductKeywordAlertRepository;
 import com.onenth.OneNth.domain.member.settings.alert.keywordAlert.repository.RegionKeywordAlertRepository;
-import com.onenth.OneNth.domain.member.settings.alert.keywordAlert.service.KeywordAlertCommandServiceImpl;
 import com.onenth.OneNth.domain.member.settings.alert.keywordAlert.util.KeywordAlertSortUtil;
 import com.onenth.OneNth.global.apiPayload.code.status.ErrorStatus;
 import com.onenth.OneNth.global.apiPayload.exception.GeneralException;
@@ -19,8 +18,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -46,6 +43,7 @@ public class GeneralAlertQueryServiceImpl implements GeneralAlertQueryService {
         List<RegionKeywordAlert> regionKeywordAlerts = regionKeywordAlertRepository.findAllByMember(member);
 
         GeneralAlertResponseDTO.GeneralAlertSummary reviewAlertSummary = GeneralAlertConverter.toGeneralAlertSummary(AlertType.REVIEW, memberAlertSetting);
+        GeneralAlertResponseDTO.GeneralAlertSummary commentAlertSummary = GeneralAlertConverter.toGeneralAlertSummary(AlertType.COMMENT, memberAlertSetting);
 
         List<Object> mergedAlerts = KeywordAlertSortUtil.mergeAndSortAlerts(productKeywordAlerts, regionKeywordAlerts);
 
@@ -53,6 +51,6 @@ public class GeneralAlertQueryServiceImpl implements GeneralAlertQueryService {
                 .map(keywordAlert -> GeneralAlertConverter.toKeywordAlertSummary(keywordAlert))
                 .collect(Collectors.toList());
 
-        return GeneralAlertConverter.toGetAllAlertSettingsResponseDTO(reviewAlertSummary, keywordAlertSummaryList);
+        return GeneralAlertConverter.toGetAllAlertSettingsResponseDTO(reviewAlertSummary, commentAlertSummary, keywordAlertSummaryList);
     }
 }


### PR DESCRIPTION
## 📌 작업 내용

> 게시글 댓글 알림 on/off 기능 구현
> - `AlertType`에 `COMMENT` 추가
> - `MemberAlertSetting`에 `commentAlerts` 필드 추가
> - 회원가입 시 기본값 true 저장
> - 알림 설정 전체 조회 API에 댓글 알림 여부 반환

## ✨ 참고 사항

> 

## 🧩 연관 이슈

> close #153 


<br>